### PR TITLE
Fixed bug with multiple multi-line comments.

### DIFF
--- a/Sources/Core/Data/Grammar/SequenceCharGroupUnit.h
+++ b/Sources/Core/Data/Grammar/SequenceCharGroupUnit.h
@@ -2,7 +2,7 @@
  * @file Core/Data/Grammar/SequenceCharGroupUnit.h
  * Contains the header of class Core::Data::Grammar::SequenceCharGroupUnit.
  *
- * @copyright Copyright (C) 2018 Sarmad Khalid Abdullah
+ * @copyright Copyright (C) 2019 Sarmad Khalid Abdullah
  *
  * @license This file is released under Alusus Public License, Version 1.0.
  * For details on usage and copying conditions read the full license in the
@@ -48,6 +48,10 @@ class SequenceCharGroupUnit : public CharGroupUnit
   {
   }
 
+  public: SequenceCharGroupUnit(WChar s, WChar e) : startCode(s), endCode(e)
+  {
+  }
+
   public: SequenceCharGroupUnit(Char const *s, Char const *e)
   {
     this->setStartCode(s);
@@ -59,6 +63,11 @@ class SequenceCharGroupUnit : public CharGroupUnit
 
   public: virtual ~SequenceCharGroupUnit()
   {
+  }
+
+  public: static SharedPtr<SequenceCharGroupUnit> create(WChar s, WChar e)
+  {
+    return std::make_shared<SequenceCharGroupUnit>(s, e);
   }
 
   public: static SharedPtr<SequenceCharGroupUnit> create(Char const *s, Char const *e)

--- a/Sources/Core/Data/Grammar/StandardFactory.cpp
+++ b/Sources/Core/Data/Grammar/StandardFactory.cpp
@@ -137,23 +137,9 @@ void StandardFactory::createCharGroupDefinitions()
   });
   this->set(S("root.LexerDefs.Letter"), CharGroupDefinition::create(letterCharGroup));
 
-  // any characters : char 'a'..'z', 'A'..'Z', 0h0620..0h065F, 0h066E..0h06DC, ' '..@,{..?, \r, \n, \t, `, ؟, _;
-  SharedPtr<CharGroupUnit> anyCharGroup = UnionCharGroupUnit::create({
-    SequenceCharGroupUnit::create(S("a"), S("z")),
-    SequenceCharGroupUnit::create(S("A"), S("Z")),
-    SequenceCharGroupUnit::create(S("_"), S("_")),
-    SequenceCharGroupUnit::create(S("ؠ"), S("ٟ")),
-    SequenceCharGroupUnit::create(S("ٮ"), S("ۜ")),
-    SequenceCharGroupUnit::create(S(" "), S("@")),
-    SequenceCharGroupUnit::create(S("{"), S("¿")),
-    RandomCharGroupUnit::create(S("\r\n\t`؟_"))
-  });
-
   // AnyChar : char any;
   this->set(S("root.LexerDefs.AnyChar"), CharGroupDefinition::create(
-    UnionCharGroupUnit::create({
-      anyCharGroup
-    })
+    SequenceCharGroupUnit::create(WCHAR_MIN, WCHAR_MAX)
   ));
 
   // AnyCharNoEs : char !('\\');
@@ -629,8 +615,9 @@ void StandardFactory::createTokenDefinitions()
     })}
   }));
 
+  // ignore { "/*" + any*(0,endless) + "*/" }
   this->set(S("root.LexerDefs.MultilineComment"), SymbolDefinition::create({
-    {S("flags"), TiInt::create(SymbolFlags::ROOT_TOKEN|SymbolFlags::IGNORED_TOKEN)}
+    {S("flags"), TiInt::create(SymbolFlags::ROOT_TOKEN|SymbolFlags::IGNORED_TOKEN|SymbolFlags::PREFER_SHORTER)}
   }, {
     {S("term"), ConcatTerm::create({}, {
       {S("terms"), List::create({}, {

--- a/Sources/Core/Data/Grammar/grammar.h
+++ b/Sources/Core/Data/Grammar/grammar.h
@@ -3,7 +3,7 @@
  * Contains the definitions and include statements of all types in the Data::Grammar
  * namespace.
  *
- * @copyright Copyright (C) 2018 Sarmad Khalid Abdullah
+ * @copyright Copyright (C) 2019 Sarmad Khalid Abdullah
  *
  * @license This file is released under Alusus Public License, Version 1.0.
  * For details on usage and copying conditions read the full license in the
@@ -75,8 +75,12 @@ s_enum(TermFlags, ERROR_SYNC_TERM=(1<<16), ONE_ROUTE_TERM=(1<<17));
  *             by the lexer when it starts a new token. The lexer loops through
  *             all symbols in the lexer module that has this flag set and skips
  *             other symbol definitions.
+ * IGNORED_TOKEN: Specifies that this token should be ignroed. This is used for
+ *                things like spaces and comments.
+ * PREFER_SHORTER: Prefer the shorter version of a multiple tokens matching a
+ *                 given rule.
  */
-s_enum(SymbolFlags, ROOT_TOKEN=(1<<16), IGNORED_TOKEN=(1<<17));
+s_enum(SymbolFlags, ROOT_TOKEN=(1<<16), IGNORED_TOKEN=(1<<17), PREFER_SHORTER=(1<<18));
 
 } // namespace
 

--- a/Sources/Core/Processing/processing.h
+++ b/Sources/Core/Processing/processing.h
@@ -3,7 +3,7 @@
  * Contains the definitions and include statements for all types used for
  * processing.
  *
- * @copyright Copyright (C) 2018 Sarmad Khalid Abdullah
+ * @copyright Copyright (C) 2019 Sarmad Khalid Abdullah
  *
  * @license This file is released under Alusus Public License, Version 1.0.
  * For details on usage and copying conditions read the full license in the
@@ -231,13 +231,14 @@ s_enum(ParserStateTerminationCause, UNKNOWN = 0, SYNTAX_ERROR, MERGED_WITH_HIGHE
  *                the data will be added to that list instead of to a child list.
  */
 s_enum(ParsingFlags,
-       ENFORCE_LIST_OBJ = 1,
-       ENFORCE_LIST_ITEM = 2,
-       ENFORCE_ROUTE_OBJ = 4,
-       ENFORCE_PROD_OBJ = 8,
-       ENFORCE_TOKEN_OBJ = 16,
-       ENFORCE_TOKEN_OMIT = 32,
-       PASS_ITEMS_UP = 64);
+  ENFORCE_LIST_OBJ = 1,
+  ENFORCE_LIST_ITEM = 2,
+  ENFORCE_ROUTE_OBJ = 4,
+  ENFORCE_PROD_OBJ = 8,
+  ENFORCE_TOKEN_OBJ = 16,
+  ENFORCE_TOKEN_OMIT = 32,
+  PASS_ITEMS_UP = 64
+);
 
 } } // namespace
 

--- a/Sources/Tests/Core/misc.alusus
+++ b/Sources/Tests/Core/misc.alusus
@@ -28,6 +28,14 @@ def a: {
     hashVar = (a:1, b:2, c:3);
     bracketVar = a + (b + c);
 
+    /*
+     * another
+     * multiline
+     * comment
+     * تعليق
+     * متعدد
+     * الأسطر
+     */
     do s:10;
   };
 

--- a/Sources/Tests/Core/misc.alusus.output
+++ b/Sources/Tests/Core/misc.alusus.output
@@ -1,7 +1,7 @@
 ERROR CP1001 @ (4,11): Parser syntax error.
 ERROR CP1001 @ (9,12): Parser syntax error.
 ERROR CP1001 @ (17,7): Parser syntax error.
-ERROR CP1001 @ (31,9): Parser syntax error.
+ERROR CP1001 @ (39,9): Parser syntax error.
 ------------------ Parsed Data Dump ------------------
 Scope [Statements.StmtList]
  ParamPass () [Expression.ParamPassExp]


### PR DESCRIPTION
The bug was caused by the Lexer considering two separate
multiline comments  to be one long comment starting with
the opening tag of the first comment and ending with the
closing tag of the second.