### PR TITLE
Support building Alusus on macOS

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -43,15 +43,29 @@ endif()
 # Prepare compile and link flags.
 STRING(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_UPPER)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  message(STATUS "Using Clang")
   # CLang options
   set(Alusus_COMPILE_FLAGS "${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE_UPPER}} -Werror=return-type -Wunused-variable -Winit-self -Wuninitialized -Wunused-const-variable -Wno-unused-result -fno-rtti")
   set(Alusus_COMPILE_FLAGS "${Alusus_COMPILE_FLAGS} -std=c++17")
-  set(CMAKE_SKIP_RPATH TRUE)
-  set(CMAKE_EXE_LINKER_FLAGS "-Wl,-rpath,'$ORIGIN',--enable-new-dtags")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   # GCC options
+  message(STATUS "Using GCC")
   set(Alusus_COMPILE_FLAGS "${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE_UPPER}} -Werror=return-type -Wunused-variable -Winit-self -Wuninitialized -Wunused-but-set-parameter -Wunused-but-set-variable -Wno-unused-result -fno-rtti")
   set(Alusus_COMPILE_FLAGS "${Alusus_COMPILE_FLAGS} -std=c++17")
+endif()
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  # macOS has a different mechanism for RPATH than Linux and requires special
+  # handling. More information can be found here:
+  #
+  # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
+  #
+  # The following article also has a good explanation:
+  #
+  # https://blogs.oracle.com/dipol/dynamic-libraries,-rpath,-and-mac-os
+  set(CMAKE_MACOSX_RPATH TRUE)
+  set(CMAKE_EXE_LINKER_FLAGS "-Wl,-rpath,@executable_path")
+else()
   set(CMAKE_SKIP_RPATH TRUE)
   set(CMAKE_EXE_LINKER_FLAGS "-Wl,-rpath,'$ORIGIN',--enable-new-dtags")
 endif()

--- a/Sources/Core/CMakeLists.txt
+++ b/Sources/Core/CMakeLists.txt
@@ -64,7 +64,20 @@ set_target_properties(AlususCoreLib PROPERTIES VERSION ${AlususVersion})
 set_target_properties(AlususCore PROPERTIES OUTPUT_NAME alusus)
 set_target_properties(AlususCore PROPERTIES DEBUG_OUTPUT_NAME alusus.dbg)
 set_target_properties(AlususCore PROPERTIES VERSION ${AlususVersion})
-set_target_properties(AlususCore PROPERTIES LINK_FLAGS "-Wl,-rpath=$ORIGIN -Wl,-rpath=$ORIGIN/../Lib/")
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  # macOS has a different mechanism for RPATH than Linux and requires special
+  # handling. More information can be found here:
+  #
+  # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
+  #
+  # The following article also has a good explanation:
+  #
+  # https://blogs.oracle.com/dipol/dynamic-libraries,-rpath,-and-mac-os
+  set_target_properties(AlususCore PROPERTIES LINK_FLAGS "-Wl,-rpath,@executable_path,-rpath,@executable_path/../Lib/")
+else()
+  set_target_properties(AlususCore PROPERTIES LINK_FLAGS "-Wl,-rpath,$ORIGIN,-rpath,$ORIGIN/../Lib/")
+endif()
 
 # Copy libary header files to installation directory.
 install_files("/Include/Core" FILES core.h core_global_storage.h)

--- a/Sources/Core/Data/Grammar/LexerModule.h
+++ b/Sources/Core/Data/Grammar/LexerModule.h
@@ -13,6 +13,8 @@
 #ifndef CORE_DATA_GRAMMAR_LEXERMODULE_H
 #define CORE_DATA_GRAMMAR_LEXERMODULE_H
 
+#include <unordered_map>
+
 namespace Core::Data::Grammar
 {
 

--- a/Sources/Core/Main/main.cpp
+++ b/Sources/Core/Main/main.cpp
@@ -12,6 +12,9 @@
 
 #include "core.h"
 #include <stdio.h>  /* defines FILENAME_MAX */
+#if __APPLE__
+  #include <mach-o/dyld.h>
+#endif
 #ifdef WINDOWS
   #include <direct.h>
   #include <windows.h>
@@ -56,6 +59,11 @@ std::string getModuleDirectory()
 
   #ifdef WINDOWS
     std::string path(currentPath.data(), GetModuleFileName(NULL, currentPath.data(), currentPath.size()));
+  #elif __APPLE__
+    uint32_t size = FILENAME_MAX;
+    // TODO: Check the result.
+    auto res = _NSGetExecutablePath(currentPath.data(), &size);
+    std::string path(currentPath.data());
   #else
     ssize_t count = readlink("/proc/self/exe", currentPath.data(), currentPath.size());
     std::string path(currentPath.data(), (count > 0) ? count : 0);

--- a/Tools/BuildSrc/install_dep.py
+++ b/Tools/BuildSrc/install_dep.py
@@ -17,7 +17,15 @@ def install_package(package, verbose=False):
     except ImportError:
         if not verbose:
             with open(os.devnull, "w") as f:
-                subprocess.call([sys.executable, '-m', 'pip', 'install', '--user', package], stdout=f, stderr=subprocess.STDOUT)
+                subprocess.call([sys.executable, '-m', 'pip', 'install',
+                                 '--user', package], stdout=f, stderr=subprocess.STDOUT)
         else:
-            subprocess.call([sys.executable, '-m', 'pip', 'install', '--user', package])
+            subprocess.call([sys.executable, '-m', 'pip',
+                             'install', '--user', package])
         reload(site)
+
+
+install_package('argparse')
+install_package('termcolor')
+install_package('wget')
+install_package('colorama')

--- a/Tools/build.cmd
+++ b/Tools/build.cmd
@@ -1,5 +1,6 @@
 REM We have migrated the build scripts to Python 3.4+ (we will not support any Python version lower than that).
 @echo off
 set SCRIPT_DIR=%~dp0
+python "%SCRIPT_DIR%\BuildSrc\install_dep.py" %*
 python "%SCRIPT_DIR%\BuildSrc\build.py" %*
 exit /b %errorlevel%

--- a/Tools/build.sh
+++ b/Tools/build.sh
@@ -4,5 +4,6 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 SCRIPT_DIR="$SCRIPT_DIR"
 shopt -s expand_aliases
+python3 "$SCRIPT_DIR/BuildSrc/install_dep.py" "$@"
 python3 "$SCRIPT_DIR/BuildSrc/build.py" "$@"
 exit $?


### PR DESCRIPTION
Support building Alusus on macOS

I made the necessary changes to be able to build on macOS. I used macOS Mojave 10.14.6 (18G3020) and Clang with Apple LLVM version 10.0.1 (clang-1001.0.46.4).

I had to make multiple changes to make it work. First, the build script was assuming the dynamic library to always have the `.so` extension, which is not the case for macOS; macOS uses `.dylib` extension.

The second change I had to do was removing the `--enable-new-dtags` from the linker arguments as the Clang on my machine complained about this argument. Furthermore, I had to include `unordered_map` in `LexerModule.h` as I experienced compilation errors.

The final change I had to make was in relation to `rpath` as it is handled differently on macOS than on Linux. This is explained well in [this article](https://blogs.oracle.com/dipol/dynamic-libraries,-rpath,-and-mac-os) and [this article](https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling) but briefly to have macOS looks in the rpath directories, the dynamic library has to be referenced like @rpath/libSomething.dylib. When macOS sees @rpath it will search for libSomething in the following directories in order:

- DYLD_LIBRARY_PATH
- RPATH
- builtin directories
- DYLD_FALLBACK_LIBRARY_PATH

For more details, you can refer to the articles I linked above.

Here are the tests I did to confirm the rpath configuration in the executable and dynamic libraries are correct:

```
otool -L ./Bin/alusus.dbg-0.6.1
./Bin/alusus.dbg-0.6.1:
        @rpath/libalusus_storage.0.6.dylib (compatibility version 0.6.0, current version 0.6.1)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 400.9.4)
```

As you can see, the `libalusus_storage` is searched under the rpath. Furthermore, executing `otool -l` and grepping for rpaths, I could see the right paths added:

```
otool -l ./Bin/alusus.dbg-0.6.1 | grep LC_RPATH -A2
          cmd LC_RPATH
      cmdsize 32
          path @executable_path (offset 12)
--
          cmd LC_RPATH
      cmdsize 32
          path @executable_path (offset 12)
--
          cmd LC_RPATH
      cmdsize 40
          path @executable_path/../Lib/ (offset 12)
```

Notice that macOS doesn't support the `$ORIGIN` so instead I used the `@executable_path` token which refers to where the executable path lives, which in this case refers to the `Bin` directory. Also notice that @executable_path is added twice, which I believe is because the root `CMakeLists.txt` file also add the @executable_path (or $ORIGIN in case of Linux) to the rpath flag of the linker, in addition to the one being added by `Core/CMakeLists.txt`. I think this might be the case whether Linux though I haven't tested it.

As for `libalusus_spp` and `libalusus_storage` executing `otool -D` on them confirm they have the `@rpath` prefix:

```
otool -D ./Lib/libalusus_spp.dbg.0.6.1.dylib
./Lib/libalusus_spp.dbg.0.6.1.dylib:
@rpath/libalusus_spp.dbg.0.6.dylib

otool -D ./Lib/libalusus_storage.0.6.dylib
./Lib/libalusus_storage.0.6.dylib:
@rpath/libalusus_storage.0.6.dylib
```

Finally, I confirmed that I was able to execute `alusus.dbg` without
having to be under the `Lib folder:

```
./Bin/alusus.dbg
Alusus Language
Version 0.6.1-GIT902af07 (2020-04-19)
Copyright (C) 2020 Sarmad Khalid Abdullah
```