### PR TITLE
Fixed a bug in BuildManager.

### DIFF
--- a/Sources/Spp/BuildManager.cpp
+++ b/Sources/Spp/BuildManager.cpp
@@ -15,6 +15,15 @@
 namespace Spp
 {
 
+BuildManager::~BuildManager()
+{
+  // Reset all build data to avoid possible segmentation faults caused by destructing LLVM objects in the wrong order.
+  this->resetBuild(BuildManager::BuildType::JIT);
+  this->resetBuild(BuildManager::BuildType::EVAL);
+  this->resetBuild(BuildManager::BuildType::OFFLINE);
+}
+
+
 //==============================================================================
 // Initialization Functions
 
@@ -59,7 +68,7 @@ void BuildManager::initTargets()
 {
   this->jitEda.setIdPrefix("jit");
   this->jitBuildTarget = std::make_shared<LlvmCodeGen::JitBuildTarget>(this->globalItemRepo);
-  this->jitTargetGenerator = std::make_shared<LlvmCodeGen::TargetGenerator>(this->jitBuildTarget.get(), true);
+  this->jitTargetGenerator = std::make_shared<LlvmCodeGen::TargetGenerator>(this->jitBuildTarget.get(), false);
   this->jitTargetGenerator->setupBuild();
 
   this->evalEda.setIdPrefix("eval");

--- a/Sources/Spp/BuildManager.h
+++ b/Sources/Spp/BuildManager.h
@@ -101,9 +101,7 @@ class BuildManager : public TiObject, public DynamicBinding, public DynamicInter
     this->initTargets();
   }
 
-  public: virtual ~BuildManager()
-  {
-  }
+  public: virtual ~BuildManager();
 
 
   //============================================================================


### PR DESCRIPTION
* Fixed an issue caused by destructing LLVM objects in the wrong order
  resulting in segfaults.
* Use single global LLVM module for JIT build target instead of
  per-function modules.