### PR TITLE
Support defining properties in user types.

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install dependencies
-      run: sudo apt-get install -y git build-essential cmake zlib1g-dev libssl-dev python3 python3-pip ruby ruby-dev rpm && sudo gem install --no-ri --no-rdoc fpm
+      run: sudo apt-get install -y git build-essential cmake zlib1g-dev libssl-dev python3 python3-pip ruby ruby-dev rpm && sudo gem install --no-document fpm
     - name: Install python3 dependencies
       run: |
         export SETUPTOOLS_USE_DISTUTILS=stdlib

--- a/Sources/Core/Data/Ast/ast.cpp
+++ b/Sources/Core/Data/Ast/ast.cpp
@@ -50,10 +50,8 @@ Bool mergeDefinition(
   Core::Data::Ast::Identifier ref({{ S("value"), def->getName() }});
   Bool result = true;
   Bool found = false;
-  seeker->foreach(&ref, target->getTiObject(),
-    [=,&result,&found](Seeker::Action action, TiObject *obj)->Seeker::Verb {
-      if (action != Seeker::Action::TARGET_MATCH) return Seeker::Verb::MOVE;
-
+  seeker->extForeach(&ref, target->getTiObject(),
+    [=,&result,&found](TiInt action, TiObject *obj)->Seeker::Verb {
       found = true;
       auto targetObj = ti_cast<Mergeable>(obj);
       if (targetObj == 0) {

--- a/Sources/Core/Data/Ast/ast.cpp
+++ b/Sources/Core/Data/Ast/ast.cpp
@@ -51,7 +51,9 @@ Bool mergeDefinition(
   Bool result = true;
   Bool found = false;
   seeker->foreach(&ref, target->getTiObject(),
-    [=,&result,&found](TiObject *obj, Notices::Notice *notice)->Seeker::Verb {
+    [=,&result,&found](Seeker::Action action, TiObject *obj)->Seeker::Verb {
+      if (action != Seeker::Action::TARGET_MATCH) return Seeker::Verb::MOVE;
+
       found = true;
       auto targetObj = ti_cast<Mergeable>(obj);
       if (targetObj == 0) {

--- a/Sources/Core/Data/Seeker.h
+++ b/Sources/Core/Data/Seeker.h
@@ -31,7 +31,12 @@ class Seeker : public TiObject, public DynamicBinding, public DynamicInterfacing
   // Types
 
   public: ti_s_enum(Verb, TiInt, "Core.Data", "Core", "alusus.org",
-    MOVE, STOP, PERFORM_AND_MOVE, PERFORM_AND_STOP, SKIP, SKIP_GROUP
+    STOP = 0,
+    MOVE = 1,
+    PERFORM = 2,
+    PERFORM_AND_MOVE = 2 | 1,
+    SKIP = 4 | 1,
+    SKIP_GROUP = 8 | 4 | 1
   );
   public: ti_s_enum(Action, TiInt, "Core.Data", "Core", "alusus.org",
     TARGET_MATCH,
@@ -46,11 +51,12 @@ class Seeker : public TiObject, public DynamicBinding, public DynamicInterfacing
   public: s_enum(Flags,
     SKIP_OWNERS = 1,
     SKIP_OWNED = 2,
-    SKIP_USES = 4
+    SKIP_USES = 4,
+    SKIP_USES_FOR_ALIASES = 8
   );
-  public: typedef std::function<Verb(Action action, TiObject *&obj)> SetCallback;
-  public: typedef std::function<Verb(Action action, TiObject *obj)> RemoveCallback;
-  public: typedef std::function<Verb(Action action, TiObject *obj)> ForeachCallback;
+  public: typedef std::function<Verb(TiInt action, TiObject *&obj)> SetCallback;
+  public: typedef std::function<Verb(TiInt action, TiObject *obj)> RemoveCallback;
+  public: typedef std::function<Verb(TiInt action, TiObject *obj)> ForeachCallback;
 
 
   //============================================================================
@@ -137,12 +143,12 @@ class Seeker : public TiObject, public DynamicBinding, public DynamicInterfacing
 
   public: static Bool isPerform(Verb verb)
   {
-    return verb == Verb::PERFORM_AND_STOP || verb == Verb::PERFORM_AND_MOVE;
+    return (verb & Verb::PERFORM) != 0;
   }
 
   public: static Bool isMove(Verb verb)
   {
-    return verb == Verb::MOVE || verb == Verb::PERFORM_AND_MOVE;
+    return (verb & Verb::MOVE) != 0;
   }
 
   /// @}
@@ -153,6 +159,7 @@ class Seeker : public TiObject, public DynamicBinding, public DynamicInterfacing
   public: METHOD_BINDING_CACHE(set, Verb, (TiObject const*, TiObject*, SetCallback const&, Word));
   public: METHOD_BINDING_CACHE(remove, Verb, (TiObject const*, TiObject*, RemoveCallback const&, Word));
   public: METHOD_BINDING_CACHE(foreach, Verb, (TiObject const*, TiObject*, ForeachCallback const&, Word));
+  public: METHOD_BINDING_CACHE(extForeach, Verb, (TiObject const*, TiObject*, ForeachCallback const&, Word));
 
   private: static Verb _set(
     TiObject *self, TiObject const *ref, TiObject *target, SetCallback const &cb, Word flags
@@ -161,6 +168,9 @@ class Seeker : public TiObject, public DynamicBinding, public DynamicInterfacing
     TiObject *self, TiObject const *ref, TiObject *target, RemoveCallback const &cb, Word flags
   );
   private: static Verb _foreach(
+    TiObject *self, TiObject const *ref, TiObject *target, ForeachCallback const &cb, Word flags
+  );
+  private: static Verb _extForeach(
     TiObject *self, TiObject const *ref, TiObject *target, ForeachCallback const &cb, Word flags
   );
 

--- a/Sources/Core/Data/Seeker.h
+++ b/Sources/Core/Data/Seeker.h
@@ -31,12 +31,26 @@ class Seeker : public TiObject, public DynamicBinding, public DynamicInterfacing
   // Types
 
   public: ti_s_enum(Verb, TiInt, "Core.Data", "Core", "alusus.org",
-    MOVE, STOP, PERFORM_AND_MOVE, PERFORM_AND_STOP
+    MOVE, STOP, PERFORM_AND_MOVE, PERFORM_AND_STOP, SKIP, SKIP_GROUP
   );
-  public: s_enum(Flags, SKIP_OWNERS = 1, SKIP_OWNED = 2, SKIP_USES = 4);
-  public: typedef std::function<Verb(TiObject *&obj, Notices::Notice *notice)> SetCallback;
-  public: typedef std::function<Verb(TiObject *obj, Notices::Notice *notice)> RemoveCallback;
-  public: typedef std::function<Verb(TiObject *obj, Notices::Notice *notice)> ForeachCallback;
+  public: ti_s_enum(Action, TiInt, "Core.Data", "Core", "alusus.org",
+    TARGET_MATCH,
+    OWNER_SCOPE,
+    USE_SCOPE,
+    USE_SCOPES_START,
+    USE_SCOPES_END,
+    ALIAS_TRACE_START,
+    ALIAS_TRACE_END,
+    ERROR
+  );
+  public: s_enum(Flags,
+    SKIP_OWNERS = 1,
+    SKIP_OWNED = 2,
+    SKIP_USES = 4
+  );
+  public: typedef std::function<Verb(Action action, TiObject *&obj)> SetCallback;
+  public: typedef std::function<Verb(Action action, TiObject *obj)> RemoveCallback;
+  public: typedef std::function<Verb(Action action, TiObject *obj)> ForeachCallback;
 
 
   //============================================================================

--- a/Sources/Core/Processing/Handlers/DumpAstParsingHandler.cpp
+++ b/Sources/Core/Processing/Handlers/DumpAstParsingHandler.cpp
@@ -32,9 +32,9 @@ void DumpAstParsingHandler::onProdEnd(Parser *parser, ParserState *state)
   try {
     Bool found = false;
     this->rootManager->getSeeker()->foreach(data, state->getDataStack(),
-      [=, &found](TiObject *obj, Notices::Notice*)->SeekVerb
+      [=, &found](Core::Data::Seeker::Action action, TiObject *obj)->SeekVerb
       {
-        if (obj != 0) {
+        if (action == Core::Data::Seeker::Action::TARGET_MATCH && obj != 0) {
           outStream << S("------------------ Parsed Data Dump ------------------\n");
           dumpData(outStream, obj, 0);
           outStream << S("\n------------------------------------------------------\n");

--- a/Sources/Core/Processing/Handlers/DumpAstParsingHandler.cpp
+++ b/Sources/Core/Processing/Handlers/DumpAstParsingHandler.cpp
@@ -32,7 +32,7 @@ void DumpAstParsingHandler::onProdEnd(Parser *parser, ParserState *state)
   try {
     Bool found = false;
     this->rootManager->getSeeker()->foreach(data, state->getDataStack(),
-      [=, &found](Core::Data::Seeker::Action action, TiObject *obj)->SeekVerb
+      [=, &found](TiInt action, TiObject *obj)->SeekVerb
       {
         if (action == Core::Data::Seeker::Action::TARGET_MATCH && obj != 0) {
           outStream << S("------------------ Parsed Data Dump ------------------\n");

--- a/Sources/Spp/Ast/ArrayType.cpp
+++ b/Sources/Spp/Ast/ArrayType.cpp
@@ -20,11 +20,12 @@ namespace Spp::Ast
 
 Type* ArrayType::getContentType(Helper *helper) const
 {
-  if (this->contentTypeRef == 0) {
-    this->contentTypeRef = helper->getRootManager()->parseExpression(S("type"));
+  static TioSharedPtr contentTypeRef;
+  if (contentTypeRef == 0) {
+    contentTypeRef = helper->getRootManager()->parseExpression(S("type"));
   }
   auto typeBox = ti_cast<TioWeakBox>(
-    helper->getSeeker()->doGet(this->contentTypeRef.get(), this->getOwner())
+    helper->getSeeker()->doGet(contentTypeRef.get(), this->getOwner())
   );
   if (typeBox == 0) return 0;
   auto type = typeBox->get().ti_cast_get<Spp::Ast::Type>();
@@ -37,11 +38,12 @@ Type* ArrayType::getContentType(Helper *helper) const
 
 Word ArrayType::getSize(Helper *helper) const
 {
-  if (this->sizeRef == 0) {
-    this->sizeRef = helper->getRootManager()->parseExpression(S("size"));
+  static TioSharedPtr sizeRef;
+  if (sizeRef == 0) {
+    sizeRef = helper->getRootManager()->parseExpression(S("size"));
   }
   auto size = ti_cast<Core::Data::Ast::IntegerLiteral>(
-    helper->getSeeker()->doGet(this->sizeRef.get(), this->getOwner())
+    helper->getSeeker()->doGet(sizeRef.get(), this->getOwner())
   );
   if (size == 0) {
     throw EXCEPTION(GenericException, S("Could not find size value."));

--- a/Sources/Spp/Ast/ArrayType.h
+++ b/Sources/Spp/Ast/ArrayType.h
@@ -28,13 +28,6 @@ class ArrayType : public DataType
 
 
   //============================================================================
-  // Member Variables
-
-  private: mutable TioSharedPtr contentTypeRef;
-  private: mutable TioSharedPtr sizeRef;
-
-
-  //============================================================================
   // Constructors & Destructor
 
   IMPLEMENT_EMPTY_CONSTRUCTOR(ArrayType);

--- a/Sources/Spp/Ast/CalleeTracer.cpp
+++ b/Sources/Spp/Ast/CalleeTracer.cpp
@@ -26,11 +26,13 @@ void CalleeTracer::initBindingCaches()
     &this->lookupCallee_function,
     &this->lookupCallee_type,
     &this->lookupCallee_template,
+    &this->lookupCallee_scope,
+    &this->lookupCallee_argPack,
     &this->lookupCallee_var,
+    &this->lookupCallee_literal,
     &this->lookupCallee_funcPtr,
     &this->lookupCallee_customOp,
-    &this->lookupCallee_builtInOp,
-    &this->lookupReferenceTarget
+    &this->lookupCallee_builtInOp
   });
 }
 
@@ -42,11 +44,13 @@ void CalleeTracer::initBindings()
   this->lookupCallee_function = &CalleeTracer::_lookupCallee_function;
   this->lookupCallee_type = &CalleeTracer::_lookupCallee_type;
   this->lookupCallee_template = &CalleeTracer::_lookupCallee_template;
+  this->lookupCallee_scope = &CalleeTracer::_lookupCallee_scope;
+  this->lookupCallee_argPack = &CalleeTracer::_lookupCallee_argPack;
   this->lookupCallee_var = &CalleeTracer::_lookupCallee_var;
+  this->lookupCallee_literal = &CalleeTracer::_lookupCallee_literal;
   this->lookupCallee_funcPtr = &CalleeTracer::_lookupCallee_funcPtr;
   this->lookupCallee_customOp = &CalleeTracer::_lookupCallee_customOp;
   this->lookupCallee_builtInOp = &CalleeTracer::_lookupCallee_builtInOp;
-  this->lookupReferenceTarget = &CalleeTracer::_lookupReferenceTarget;
 }
 
 
@@ -58,70 +62,87 @@ void CalleeTracer::_lookupCallee(TiObject *self, CalleeLookupRequest &request, C
   PREPARE_SELF(tracer, CalleeTracer);
 
   if (request.ref != 0) {
-    Core::Data::Node *prevNode = 0;
-    tracer->getSeeker()->foreach(request.ref, request.target,
-      [=, &request, &result, &prevNode]
-        (TiObject *obj, Core::Notices::Notice *ntc)->Core::Data::Seeker::Verb
-        {
-          if (ntc != 0) {
-            if (result.isNew()) result.notice = getSharedPtr(ntc);
-            return Core::Data::Seeker::Verb::MOVE;
-          }
-          if (obj == 0) return Core::Data::Seeker::Verb::MOVE;
-
-          // Unbox if we have a box.
-          auto box = ti_cast<TioWeakBox>(obj);
-          if (box != 0) obj = box->get().get();
-
-          if (
-            result.stack.getLength() > 0 && result.stack(result.stack.getLength() - 1) == obj &&
-            result.thisIndex < 0
-          ) {
-            return Core::Data::Seeker::Verb::MOVE;
-          }
-
-          // There is no need to continue searching if we already have a match and we are jumping to another level.
-          auto node = ti_cast<Core::Data::Node>(obj);
-          if (node != 0 && prevNode != 0) {
-            // If we encounter the same node again it means we moved up and encountered a use statement that took us back
-            // into the same module. In this case we can stop looking since we have moved up and we already have a match.
-            if (node == prevNode) return Core::Data::Seeker::Verb::STOP;
-
-            // If it's not the same node, then let's check the owners of the two nodes.
-            Core::Data::Node *owner = Core::Data::findOwner<Core::Data::Ast::Scope>(node);
-            // It's possible that the previous match was for a function arg, so we have to account for that since a
-            // function arg would have the same owner scope as a function sitting at the same module.
-            Core::Data::Node *prevOwner = Core::Data::findOwner<Spp::Ast::FunctionType>(prevNode);
-            if (prevOwner == 0) prevOwner = Core::Data::findOwner<Core::Data::Ast::Scope>(prevNode);
-            if (owner != prevOwner) return Core::Data::Seeker::Verb::STOP;
-          }
-
-          CalleeLookupRequest innerRequest = request;
-          CalleeLookupResult innerResult;
-          innerRequest.target = obj;
-          tracer->lookupCallee_routing(innerRequest, innerResult);
-          if (innerResult.isSuccessful()) prevNode = node;
-          CalleeTracer::selectBetterResult(innerResult, result);
-          if (
-            result.notice != 0 &&
-            result.notice->isDerivedFrom<Spp::Notices::MultipleCalleeMatchNotice>() &&
-            result.matchStatus == TypeMatchStatus::EXACT
-          ) {
-            // There is no need to continue searching if we found multiple exact matches.
-            return Core::Data::Seeker::Verb::STOP;
-          }
-
+    auto target = request.target;
+    int tracingAlias = 0;
+    auto callback = [=, &request, &result, &target, &tracingAlias]
+      (Core::Data::Seeker::Action action, TiObject *obj)->Core::Data::Seeker::Verb
+      {
+        if (action == Core::Data::Seeker::Action::ERROR) {
+          if (result.isNew()) result.notice = getSharedPtr(ti_cast<Core::Notices::Notice>(obj));
+          ASSERT(result.notice != 0);
           return Core::Data::Seeker::Verb::MOVE;
-        },
-        request.searchTargetOwners ? 0 : SeekerExtension::Flags::SKIP_OWNERS_AND_USES
-    );
+        } else if (action == Core::Data::Seeker::Action::OWNER_SCOPE) {
+          if (tracingAlias == 0 || result.isNameMatched()) return Core::Data::Seeker::Verb::SKIP_GROUP;
+          else return Core::Data::Seeker::Verb::MOVE;
+        } else if (action == Core::Data::Seeker::Action::USE_SCOPES_START) {
+          if (tracingAlias == 0 || result.isNameMatched()) return Core::Data::Seeker::Verb::SKIP;
+          else return Core::Data::Seeker::Verb::MOVE;
+        } else if (action == Core::Data::Seeker::Action::ALIAS_TRACE_START) {
+          ++tracingAlias;
+          return Core::Data::Seeker::Verb::MOVE;
+        } else if (action == Core::Data::Seeker::Action::ALIAS_TRACE_END) {
+          --tracingAlias;
+          return Core::Data::Seeker::Verb::MOVE;
+        }
 
-    // Try the injections if we don't have an exact match yet.
-    if (result.matchStatus < TypeMatchStatus::EXACT) {
-      auto helper = tracer->helper;
-      auto dataType = ti_cast<DataType>(request.target);
-      if (dataType != 0) {
-        auto block = dataType->getBody().get();
+        if (action != Core::Data::Seeker::Action::TARGET_MATCH || obj == 0) return Core::Data::Seeker::Verb::MOVE;
+
+        // Unbox if we have a box.
+        auto box = ti_cast<TioWeakBox>(obj);
+        if (box != 0) obj = box->get().get();
+
+        if (
+          result.stack.getLength() > 0 && result.stack(result.stack.getLength() - 1) == obj &&
+          result.thisIndex < 0
+        ) {
+          return Core::Data::Seeker::Verb::MOVE;
+        }
+
+        auto node = ti_cast<Core::Data::Node>(obj);
+        if (request.targetIsObject) {
+          if (node == 0 || node->findOwner<Type>() != target) {
+            // The found member was probably an alias to a non member.
+            result.notice = newSrdObj<Spp::Notices::InvalidTypeMemberNotice>(
+              Core::Data::Ast::findSourceLocation(request.astNode)
+            );
+            return Core::Data::Seeker::Verb::MOVE;
+          }
+        }
+
+        CalleeLookupRequest innerRequest = request;
+        CalleeLookupResult innerResult;
+        innerRequest.target = obj;
+        tracer->lookupCallee_routing(innerRequest, innerResult);
+        CalleeTracer::selectBetterResult(innerResult, result);
+        if (
+          result.notice != 0 &&
+          result.notice->isDerivedFrom<Spp::Notices::MultipleCalleeMatchNotice>() &&
+          result.matchStatus == TypeMatchStatus::EXACT
+        ) {
+          // There is no need to continue searching if we found multiple exact matches.
+          return Core::Data::Seeker::Verb::STOP;
+        }
+
+        return Core::Data::Seeker::Verb::MOVE;
+      };
+
+    while (target != 0) {
+      // Search the requested scope.
+      tracingAlias = 0;
+      tracer->getSeeker()->foreach(request.ref, target, callback, 0);
+
+      // Try the injections if we don't have an exact match yet.
+      if (result.matchStatus < TypeMatchStatus::EXACT) {
+        Block *block = 0;
+        auto helper = tracer->helper;
+        // Special handling for Type targets, but it's only needed if we are at the top of the stack to avoid re-testing
+        // the same block again.
+        auto dataType = target == request.target ? ti_cast<DataType>(target) : 0;
+        if (dataType != 0) {
+          block = dataType->getBody().get();
+        } else {
+          block = ti_cast<Block>(target);
+        }
         if (block != 0) {
           for (Int i = 0; i < block->getInjectionCount(); ++i) {
             auto def = ti_cast<Core::Data::Ast::Definition>(block->getInjection(i));
@@ -137,6 +158,7 @@ void CalleeTracer::_lookupCallee(TiObject *self, CalleeLookupRequest &request, C
             CalleeLookupRequest innerRequest = request;
             innerRequest.target = objType;
             innerRequest.searchTargetOwners = false;
+            innerRequest.targetIsObject = true;
             if (!noBindDef) innerRequest.thisType = refType;
             CalleeLookupResult innerResult;
             tracer->lookupCallee(innerRequest, innerResult);
@@ -151,6 +173,43 @@ void CalleeTracer::_lookupCallee(TiObject *self, CalleeLookupRequest &request, C
             if (result.matchStatus == TypeMatchStatus::EXACT) break;
           }
         }
+      }
+
+      // Try scope bridges if we haven't found any name match.
+      if (!result.isNameMatched() && !request.targetIsObject && request.searchTargetOwners) {
+        Core::Data::Ast::Scope *scope = 0;
+        // Special handling for Type targets, but it's only needed if we are at the top of the stack to avoid re-testing
+        // the same scope again.
+        auto dataType = target == request.target ? ti_cast<DataType>(target) : 0;
+        if (dataType != 0) {
+          scope = dataType->getBody().get();
+        } else {
+          scope = ti_cast<Core::Data::Ast::Scope>(target);
+        }
+        if (scope != 0) {
+          for (Int i = 0; i < scope->getBridgeCount(); ++i) {
+            auto bridgeRef = scope->getBridge(i);
+            // If the thing we are looking for is actually this bridgeRef, then we need to skip, otherwise we end up in
+            // an infinite loop.
+            if (bridgeRef->getTarget() == request.ref) continue;
+            auto bridgeTarget = tracer->getSeeker()->tryGet(
+              bridgeRef->getTarget().get(), scope, Core::Data::Seeker::Flags::SKIP_USES
+            );
+            if (bridgeTarget == 0) continue;
+
+            tracingAlias = 0;
+            auto verb = tracer->getSeeker()->foreach(request.ref, bridgeTarget, callback, 0);
+            if (verb == Core::Data::Seeker::Verb::STOP) break;
+          }
+        }
+      }
+
+      if (!request.searchTargetOwners || result.isNameMatched()) break;
+
+      target = static_cast<Core::Data::Node*>(target)->getOwner();
+      if (ti_cast<Ast::DataType>(target) != 0) {
+        // Skip the type object itself.
+        target = static_cast<Core::Data::Node*>(target)->getOwner();
       }
     }
   } else {
@@ -189,20 +248,28 @@ void CalleeTracer::_lookupCallee_routing(TiObject *self, CalleeLookupRequest &re
       auto funcType = helper->tryGetPointerContentType<FunctionType>(request.target);
       if (funcType != 0) {
         tracer->lookupCallee_funcPtr(request, result);
-      } else {
-        if (ti_cast<UserType>(request.target) != 0) {
-          tracer->lookupCallee_customOp(request, result);
-          if (result.isSuccessful()) return;
-        }
-        tracer->lookupCallee_builtInOp(request, result);
+      } else if (ti_cast<UserType>(request.target) != 0) {
+        tracer->lookupCallee_customOp(request, result);
       }
+      if (result.isSuccessful()) return;
+      tracer->lookupCallee_builtInOp(request, result);
     } else {
       tracer->lookupCallee_type(request, result);
     }
   } else if (request.target != 0 && request.target->isDerivedFrom<Template>()) {
     tracer->lookupCallee_template(request, result);
+  } else if (request.target != 0 && request.target->isDerivedFrom<Core::Data::Ast::Scope>()) {
+    tracer->lookupCallee_scope(request, result);
+  } else if (request.target != 0 && request.target->isDerivedFrom<ArgPack>()) {
+    tracer->lookupCallee_argPack(request, result);
   } else if (request.target != 0 && helper->isAstReference(request.target)) {
     tracer->lookupCallee_var(request, result);
+  } else if (request.target != 0 && request.target->isDerivedFrom<Core::Data::Ast::StringLiteral>()) {
+    tracer->lookupCallee_literal(request, result);
+  } else if (request.target != 0 && request.target->isDerivedFrom<Core::Data::Ast::IntegerLiteral>()) {
+    tracer->lookupCallee_literal(request, result);
+  } else if (request.target != 0 && request.target->isDerivedFrom<Core::Data::Ast::FloatLiteral>()) {
+    tracer->lookupCallee_literal(request, result);
   } else {
     // Invalid
     if (result.notice == 0) result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
@@ -220,12 +287,35 @@ void CalleeTracer::_lookupCallee_function(TiObject *self, CalleeLookupRequest &r
 
   auto func = static_cast<Ast::Function*>(request.target);
 
-  if (request.op != "()") {
+  if (request.op == S("[]")) {
+    result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
+    return;
+  }
+
+  // TODO: Should we skip if targetIsObject is false and the function is a member function?
+
+  if (request.op != S("()")) {
     // Only allow this check if the funciton has the proper modifier.
-    // TODO: Check function modifiers rather than generic def modifiers.
     auto def = func->findOwner<Core::Data::Ast::Definition>();
-    if (def == 0) return;
-    if (!helper->doesModifierExistOnDef(def, S("assign"))) return;
+    if (def == 0) {
+      result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
+      return;
+    }
+    auto defOp = CalleeTracer::findOperationModifier(def);
+
+    if (defOp == 0 || request.op != defOp) {
+      if (request.op == S("") && !request.targetIsObject) {
+        // We are just trying to get a reference to the function itself.
+        result.matchStatus = TypeMatchStatus::EXACT;
+        result.notice.reset();
+        result.stack.clear();
+        result.stack.add(func);
+        result.thisIndex = -2;
+      } else {
+        result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
+      }
+      return;
+    }
   }
 
   Bool useThis = !func->getType()->isBindDisabled() && request.thisType != 0;
@@ -236,7 +326,6 @@ void CalleeTracer::_lookupCallee_function(TiObject *self, CalleeLookupRequest &r
     result.stack.clear();
     result.stack.add(func);
     result.thisIndex = useThis ? -1 : -2;
-    result.type = func->getType().get();
   } else {
     result.notice = newSrdObj<Spp::Notices::ArgsMismatchNotice>();
   }
@@ -250,7 +339,10 @@ void CalleeTracer::_lookupCallee_type(TiObject *self, CalleeLookupRequest &reque
 
   auto type = static_cast<Type*>(request.target);
 
-  if (request.op == S("()")) {
+  if (request.op == S("[]")) {
+    result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
+    return;
+  } else if (request.op == S("()")) {
     // This is a constructor.
     Function *customCaster;
     static Core::Data::Ast::Identifier ref({ {S("value"), TiStr(S("~init"))} });
@@ -264,7 +356,6 @@ void CalleeTracer::_lookupCallee_type(TiObject *self, CalleeLookupRequest &reque
       // A constructor match was found.
       result.pushStack(type);
       result.thisIndex = -2;
-      result.type = type;
     } else if (
       request.argTypes->getElementCount() == 0 &&
       (type->getInitializationMethod(helper, request.ec) & TypeInitMethod::USER) == 0
@@ -275,7 +366,6 @@ void CalleeTracer::_lookupCallee_type(TiObject *self, CalleeLookupRequest &reque
       result.stack.clear();
       result.stack.add(type);
       result.thisIndex = -2;
-      result.type = type;
     } else if (
       (type->getInitializationMethod(helper, request.ec) & TypeInitMethod::USER) == 0 &&
       request.argTypes->getElementCount() == 1 &&
@@ -287,7 +377,6 @@ void CalleeTracer::_lookupCallee_type(TiObject *self, CalleeLookupRequest &reque
       result.stack.clear();
       result.stack.add(type);
       result.thisIndex = -2;
-      result.type = type;
     } else {
       // If the ref symbol we provided here was not found we'll provide a better error message to the user since
       // the user didn't manually provide this symbol.
@@ -295,6 +384,13 @@ void CalleeTracer::_lookupCallee_type(TiObject *self, CalleeLookupRequest &reque
         result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
       }
     }
+  } else if (request.op == S("")) {
+    // We are just trying to get a reference to the type itself.
+    result.matchStatus = TypeMatchStatus::EXACT;
+    result.notice.reset();
+    result.stack.clear();
+    result.stack.add(type);
+    result.thisIndex = -2;
   } else {
     result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
   }
@@ -304,6 +400,16 @@ void CalleeTracer::_lookupCallee_type(TiObject *self, CalleeLookupRequest &reque
 void CalleeTracer::_lookupCallee_template(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result)
 {
   PREPARE_SELF(tracer, CalleeTracer);
+
+  if (request.op == S("[]")) {
+    // We want the template itself.
+    result.matchStatus = TypeMatchStatus::EXACT;
+    result.notice.reset();
+    result.stack.clear();
+    result.stack.add(request.target);
+    result.thisIndex = -2;
+    return;
+  }
 
   // TODO: Look-up template functions as well.
   auto objType = tracer->helper->traceType(request.target);
@@ -317,15 +423,56 @@ void CalleeTracer::_lookupCallee_template(TiObject *self, CalleeLookupRequest &r
 }
 
 
+void CalleeTracer::_lookupCallee_scope(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result)
+{
+  PREPARE_SELF(tracer, CalleeTracer);
+
+  if (request.op == S("[]")) {
+    result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
+    return;
+  }
+
+  if (request.op != S("") || request.targetIsObject) {
+    result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
+  } else {
+    result.matchStatus = TypeMatchStatus::EXACT;
+    result.notice.reset();
+    result.stack.clear();
+    result.stack.add(request.target);
+    result.thisIndex = -2;
+  }
+}
+
+
+void CalleeTracer::_lookupCallee_argPack(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result)
+{
+  PREPARE_SELF(tracer, CalleeTracer);
+
+  if (request.op != S("")) {
+    result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
+    return;
+  }
+
+  result.matchStatus = TypeMatchStatus::EXACT;
+  result.notice.reset();
+  result.stack.clear();
+  result.stack.add(request.target);
+  result.thisIndex = -2;
+}
+
+
 void CalleeTracer::_lookupCallee_var(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result)
 {
   PREPARE_SELF(tracer, CalleeTracer);
   auto helper = tracer->helper;
 
-  auto def = Core::Data::findOwner<Core::Data::Ast::Definition>(ti_cast<Core::Data::Node>(request.target));
-  if (def == 0) {
-    throw EXCEPTION(GenericException, S("Unexpected error while looking for var definition."));
+  if (request.op == S("[]")) {
+    result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
+    return;
   }
+
+  auto def = ti_cast<Core::Data::Ast::Definition>(static_cast<Core::Data::Node*>(request.target)->getOwner());
+
   auto objType = ti_cast<Type>(helper->traceType(request.target));
   if (objType == 0) {
     result.notice = newSrdObj<Spp::Notices::InvalidTypeNotice>(Core::Data::Ast::findSourceLocation(request.target));
@@ -337,7 +484,23 @@ void CalleeTracer::_lookupCallee_var(TiObject *self, CalleeLookupRequest &reques
     return;
   }
 
-  Bool noBindDef = helper->isNoBindDef(def);
+  if (request.targetIsObject) {
+    if (helper->getVariableDomain(request.target) != Ast::DefinitionDomain::OBJECT) {
+      result.notice = newSrdObj<Spp::Notices::InvalidGlobalDefAccessNotice>(
+        Core::Data::Ast::findSourceLocation(request.target)
+      );
+      return;
+    }
+  } else {
+    if (helper->getVariableDomain(request.target) == Ast::DefinitionDomain::OBJECT) {
+      result.notice = newSrdObj<Spp::Notices::InvalidObjectMemberAccessNotice>(
+        Core::Data::Ast::findSourceLocation(request.target)
+      );
+      return;
+    }
+  }
+
+  Bool noBindDef = def != 0 && helper->isNoBindDef(def);
 
   CalleeLookupRequest innerRequest = request;
   innerRequest.targetIsObject = true;
@@ -356,25 +519,60 @@ void CalleeTracer::_lookupCallee_var(TiObject *self, CalleeLookupRequest &reques
 }
 
 
+void CalleeTracer::_lookupCallee_literal(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result)
+{
+  if (request.op != S("()")) {
+    // Accept any other operator and let the caller handle the built in type checking.
+    result.matchStatus = TypeMatchStatus::EXACT;
+    result.thisIndex = -2;
+    result.stack.clear();
+    result.pushStack(request.target);
+    result.notice.reset();
+  }
+}
+
+
 void CalleeTracer::_lookupCallee_funcPtr(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result)
 {
   PREPARE_SELF(tracer, CalleeTracer);
   auto helper = tracer->helper;
 
+  if (request.op == S("[]")) {
+    result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
+    return;
+  }
+
+  // TODO: Should we skip if targetIsObject is false and the function is a member function?
+
   ContainerExtender<TiObject, 1, 0> extTypes(request.argTypes);
   extTypes.setPreItem(0, request.thisType);
 
+  // Verify op against operation modifier.
+  if (request.op != "()") {
+    // Only allow this check if the funciton has the proper modifier.
+    auto def = static_cast<Core::Data::Node*>(request.target)->findOwner<Core::Data::Ast::Definition>();
+    if (def == 0) return;
+    auto defOp = CalleeTracer::findOperationModifier(def);
+    if (defOp == 0 || request.op != defOp) {
+      if (request.op == S("")) {
+        // We are just trying to get a reference to the func ptr itself.
+        result.matchStatus = TypeMatchStatus::EXACT;
+        result.notice.reset();
+        result.stack.clear();
+        result.thisIndex = -2;
+      }
+      return;
+    }
+  }
+
   auto funcType = helper->tryGetPointerContentType<FunctionType>(request.target);
-
-  // TODO: Verify op against modifier.
   Bool useThis = !funcType->isBindDisabled() && request.thisType != 0;
-
   result.matchStatus = funcType->matchCall(useThis ? &extTypes : request.argTypes, helper, request.ec);
+
   if (result.matchStatus >= TypeMatchStatus::CUSTOM_CASTER) {
     result.notice.reset();
     result.stack.clear();
     result.thisIndex = useThis ? -1 : -2;
-    result.type = funcType;
   } else {
     result.notice = newSrdObj<Spp::Notices::ArgsMismatchNotice>();
   }
@@ -384,6 +582,11 @@ void CalleeTracer::_lookupCallee_funcPtr(TiObject *self, CalleeLookupRequest &re
 void CalleeTracer::_lookupCallee_customOp(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result)
 {
   PREPARE_SELF(tracer, CalleeTracer);
+
+  if (request.op == S("[]")) {
+    result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
+    return;
+  }
 
   Core::Data::Ast::Identifier ref({ {S("value"), TiStr(request.op)} });
   CalleeLookupRequest innerRequest = request;
@@ -410,7 +613,10 @@ void CalleeTracer::_lookupCallee_builtInOp(TiObject *self, CalleeLookupRequest &
 
   auto type = static_cast<Type*>(request.target);
 
-  if (request.op == S("()")) {
+  if (request.op == S("[]")) {
+    result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
+    return;
+  } else if (request.op == S("()")) {
     // Type must be an array for () operator.
     if (type->isDerivedFrom<ArrayType>()) {
       // We have an array.
@@ -419,7 +625,6 @@ void CalleeTracer::_lookupCallee_builtInOp(TiObject *self, CalleeLookupRequest &
         helper->isImplicitlyCastableTo(request.argTypes->getElement(0), helper->getArchIntType(), request.ec)
       ) {
         result.matchStatus = TypeMatchStatus::EXACT;
-        result.type = type;
         result.thisIndex = -2;
         result.stack.clear();
         result.notice.reset();
@@ -436,12 +641,11 @@ void CalleeTracer::_lookupCallee_builtInOp(TiObject *self, CalleeLookupRequest &
       auto ms = helper->matchTargetType(request.argTypes->getElement(0), type, request.ec, caster);
       if (ms >= TypeMatchStatus::CUSTOM_CASTER) {
         result.matchStatus = ms;
-        result.type = type;
         result.thisIndex = -2;
         result.stack.clear();
         result.notice.reset();
       } else {
-        if (result.notice == 0) result.notice = newSrdObj<Spp::Notices::ArgsMismatchNotice>();
+        if (result.notice == 0) result.notice = newSrdObj<Spp::Notices::IncompatibleOperatorTypesNotice>();
       }
     } else {
       if (result.notice == 0) result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
@@ -449,58 +653,10 @@ void CalleeTracer::_lookupCallee_builtInOp(TiObject *self, CalleeLookupRequest &
   } else {
     // Accept any other operator and let the caller handle the built in type checking.
     result.matchStatus = TypeMatchStatus::EXACT;
-    result.type = type;
     result.thisIndex = -2;
     result.stack.clear();
     result.notice.reset();
   }
-}
-
-
-// TODO:
-Bool CalleeTracer::_lookupReferenceTarget(
-  TiObject *self, TiObject *astNode, Core::Data::Ast::Identifier *ref, Bool searchOwners, PlainList<TiObject> &stack
-) {
-  PREPARE_SELF(tracer, CalleeTracer);
-
-  Word currentStackSize = stack.getCount();
-  Bool symbolFound = false;
-  tracer->getSeeker()->foreach(ref, astNode,
-    [=, &symbolFound, &stack] (TiObject *obj, Core::Notices::Notice*)->Core::Data::Seeker::Verb
-    {
-      symbolFound = true;
-      stack.add(obj);
-      return Core::Data::Seeker::Verb::STOP;
-    },
-    searchOwners ? 0 : SeekerExtension::Flags::SKIP_OWNERS_AND_USES
-  );
-
-  if (!symbolFound) {
-    Block *block = 0;
-    auto dataType = ti_cast<DataType>(astNode);
-    if (dataType != 0) block = dataType->getBody().get();
-    else block = Core::Data::findOwner<Block>(ti_cast<Core::Data::Node>(astNode));
-
-    if (block != 0) {
-      for (Int i = 0; i < block->getInjectionCount(); ++i) {
-        auto def = ti_cast<Core::Data::Ast::Definition>(block->getInjection(i));
-        if (def == 0 || def->getTarget() == 0) continue;
-        if (!tracer->helper->isAstReference(def->getTarget().get())) continue;
-        auto objType = ti_cast<Type>(tracer->getSeeker()->tryGet(def->getTarget().get(), block));
-        if (objType == 0) continue;
-        objType = tracer->helper->tryGetDeepReferenceContentType(objType);
-        stack.add(def->getTarget().get());
-        if (tracer->lookupReferenceTarget(objType, ref, false, stack)) {
-          symbolFound = true;
-          break;
-        } else {
-          while (stack.getCount() > currentStackSize) stack.remove(currentStackSize);
-        }
-      }
-    }
-  }
-
-  return symbolFound;
 }
 
 
@@ -515,13 +671,45 @@ void CalleeTracer::selectBetterResult(CalleeLookupResult const &newResult, Calle
       // Better result is found.
       result = newResult;
     } else if (newResult.matchStatus == result.matchStatus) {
-      // Multiple callee match.
-      result.notice = newSrdObj<Spp::Notices::MultipleCalleeMatchNotice>();
+      // If the results are identical it means we have reached the same target twice, which can happen if the user has
+      // an alias at a parent scope with the same name pointing to the same element. In this case we ignore the second
+      // match without raising an error.
+      Bool identicalStack = true;
+      if (newResult.stack.getLength() != result.stack.getLength()) identicalStack = false;
+      else for (Int i = 0; i < newResult.stack.getLength(); ++i) {
+        if (newResult.stack(i) != result.stack(i)) {
+          identicalStack = false;
+          break;
+        }
+      }
+      if (!identicalStack) {
+        // Multiple callee match.
+        result.notice = newSrdObj<Spp::Notices::MultipleCalleeMatchNotice>();
+      }
     }
   } else if (result.matchStatus == TypeMatchStatus::NONE && result.notice == 0) {
     // It was a failed match and we don't have a previous failed match, so we'll take this match.
     result = newResult;
   }
+}
+
+
+Char const* CalleeTracer::findOperationModifier(Core::Data::Ast::Definition *def)
+{
+  auto modifiers = def->getModifiers().get();
+  if (modifiers != 0) {
+    for (Int i = 0; i < modifiers->getElementCount(); ++i) {
+      auto paramPass = ti_cast<Core::Data::Ast::ParamPass>(modifiers->getElement(i));
+      if (paramPass != 0) {
+        auto identifier = paramPass->getOperand().ti_cast_get<Core::Data::Ast::Identifier>();
+        if (identifier != 0 && identifier->getValue() == S("operation")) {
+          auto stringLiteral = paramPass->getParam().ti_cast_get<Core::Data::Ast::StringLiteral>();
+          if (stringLiteral != 0) return stringLiteral->getValue().get();
+        }
+      }
+    }
+  }
+  return 0;
 }
 
 } // namespace

--- a/Sources/Spp/Ast/CalleeTracer.cpp
+++ b/Sources/Spp/Ast/CalleeTracer.cpp
@@ -1,0 +1,527 @@
+/**
+ * @file Spp/Ast/CalleeTracer.cpp
+ * Contains the implementation of class Spp::Ast::CalleeTracer.
+ *
+ * @copyright Copyright (C) 2021 Sarmad Khalid Abdullah
+ *
+ * @license This file is released under Alusus Public License, Version 1.0.
+ * For details on usage and copying conditions read the full license in the
+ * accompanying license file or at <https://alusus.org/license.html>.
+ */
+//==============================================================================
+
+#include "spp.h"
+
+namespace Spp::Ast
+{
+
+//==============================================================================
+// Initialization Functions
+
+void CalleeTracer::initBindingCaches()
+{
+  Basic::initBindingCaches(this, {
+    &this->lookupCallee,
+    &this->lookupCallee_routing,
+    &this->lookupCallee_function,
+    &this->lookupCallee_type,
+    &this->lookupCallee_template,
+    &this->lookupCallee_var,
+    &this->lookupCallee_funcPtr,
+    &this->lookupCallee_customOp,
+    &this->lookupCallee_builtInOp,
+    &this->lookupReferenceTarget
+  });
+}
+
+
+void CalleeTracer::initBindings()
+{
+  this->lookupCallee = &CalleeTracer::_lookupCallee;
+  this->lookupCallee_routing = &CalleeTracer::_lookupCallee_routing;
+  this->lookupCallee_function = &CalleeTracer::_lookupCallee_function;
+  this->lookupCallee_type = &CalleeTracer::_lookupCallee_type;
+  this->lookupCallee_template = &CalleeTracer::_lookupCallee_template;
+  this->lookupCallee_var = &CalleeTracer::_lookupCallee_var;
+  this->lookupCallee_funcPtr = &CalleeTracer::_lookupCallee_funcPtr;
+  this->lookupCallee_customOp = &CalleeTracer::_lookupCallee_customOp;
+  this->lookupCallee_builtInOp = &CalleeTracer::_lookupCallee_builtInOp;
+  this->lookupReferenceTarget = &CalleeTracer::_lookupReferenceTarget;
+}
+
+
+//==============================================================================
+// Main Functions
+
+void CalleeTracer::_lookupCallee(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result)
+{
+  PREPARE_SELF(tracer, CalleeTracer);
+
+  if (request.ref != 0) {
+    Core::Data::Node *prevNode = 0;
+    tracer->getSeeker()->foreach(request.ref, request.target,
+      [=, &request, &result, &prevNode]
+        (TiObject *obj, Core::Notices::Notice *ntc)->Core::Data::Seeker::Verb
+        {
+          if (ntc != 0) {
+            if (result.isNew()) result.notice = getSharedPtr(ntc);
+            return Core::Data::Seeker::Verb::MOVE;
+          }
+          if (obj == 0) return Core::Data::Seeker::Verb::MOVE;
+
+          // Unbox if we have a box.
+          auto box = ti_cast<TioWeakBox>(obj);
+          if (box != 0) obj = box->get().get();
+
+          if (
+            result.stack.getLength() > 0 && result.stack(result.stack.getLength() - 1) == obj &&
+            result.thisIndex < 0
+          ) {
+            return Core::Data::Seeker::Verb::MOVE;
+          }
+
+          // There is no need to continue searching if we already have a match and we are jumping to another level.
+          auto node = ti_cast<Core::Data::Node>(obj);
+          if (node != 0 && prevNode != 0) {
+            // If we encounter the same node again it means we moved up and encountered a use statement that took us back
+            // into the same module. In this case we can stop looking since we have moved up and we already have a match.
+            if (node == prevNode) return Core::Data::Seeker::Verb::STOP;
+
+            // If it's not the same node, then let's check the owners of the two nodes.
+            Core::Data::Node *owner = Core::Data::findOwner<Core::Data::Ast::Scope>(node);
+            // It's possible that the previous match was for a function arg, so we have to account for that since a
+            // function arg would have the same owner scope as a function sitting at the same module.
+            Core::Data::Node *prevOwner = Core::Data::findOwner<Spp::Ast::FunctionType>(prevNode);
+            if (prevOwner == 0) prevOwner = Core::Data::findOwner<Core::Data::Ast::Scope>(prevNode);
+            if (owner != prevOwner) return Core::Data::Seeker::Verb::STOP;
+          }
+
+          CalleeLookupRequest innerRequest = request;
+          CalleeLookupResult innerResult;
+          innerRequest.target = obj;
+          tracer->lookupCallee_routing(innerRequest, innerResult);
+          if (innerResult.isSuccessful()) prevNode = node;
+          CalleeTracer::selectBetterResult(innerResult, result);
+          if (
+            result.notice != 0 &&
+            result.notice->isDerivedFrom<Spp::Notices::MultipleCalleeMatchNotice>() &&
+            result.matchStatus == TypeMatchStatus::EXACT
+          ) {
+            // There is no need to continue searching if we found multiple exact matches.
+            return Core::Data::Seeker::Verb::STOP;
+          }
+
+          return Core::Data::Seeker::Verb::MOVE;
+        },
+        request.searchTargetOwners ? 0 : SeekerExtension::Flags::SKIP_OWNERS_AND_USES
+    );
+
+    // Try the injections if we don't have an exact match yet.
+    if (result.matchStatus < TypeMatchStatus::EXACT) {
+      auto helper = tracer->helper;
+      auto dataType = ti_cast<DataType>(request.target);
+      if (dataType != 0) {
+        auto block = dataType->getBody().get();
+        if (block != 0) {
+          for (Int i = 0; i < block->getInjectionCount(); ++i) {
+            auto def = ti_cast<Core::Data::Ast::Definition>(block->getInjection(i));
+            if (def == 0 || def->getTarget() == 0) continue;
+            if (!helper->isAstReference(def->getTarget().get())) continue;
+            Bool isMember = helper->getVariableDomain(def) == DefinitionDomain::OBJECT;
+            if ((isMember && request.thisType == 0) || (!isMember && request.thisType != 0)) continue;
+            auto objType = helper->traceType(def->getTarget().get());
+            if (objType == 0) continue;
+            auto refType = helper->getReferenceTypeFor(objType, Ast::ReferenceMode::IMPLICIT);
+            objType = helper->tryGetDeepReferenceContentType(objType);
+            Bool noBindDef = helper->isNoBindDef(def);
+            CalleeLookupRequest innerRequest = request;
+            innerRequest.target = objType;
+            innerRequest.searchTargetOwners = false;
+            if (!noBindDef) innerRequest.thisType = refType;
+            CalleeLookupResult innerResult;
+            tracer->lookupCallee(innerRequest, innerResult);
+            if (innerResult.isSuccessful()) {
+              innerResult.pushStack(def->getTarget().get());
+              if (innerResult.thisIndex == -1) {
+                innerResult.thisIndex = noBindDef ? -1 : 0;
+              }
+            }
+            CalleeTracer::selectBetterResult(innerResult, result);
+            // No need to keep looking if we already found an exact match.
+            if (result.matchStatus == TypeMatchStatus::EXACT) break;
+          }
+        }
+      }
+    }
+  } else {
+    tracer->lookupCallee_routing(request, result);
+  }
+
+  // Did we have a matched callee?
+  if (!result.isSuccessful()) {
+    // If we have no notice it means the symbol was not found in the first place.
+    if (result.notice == 0) {
+      // If no ref symbol was provided it means we are applying an operation on a reuslt rather than searching by
+      // symbol, so in this case using InvalidOperationNotice is more appropriate than UnknownSymbolNotice.
+      if (request.ref == 0) {
+        result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
+      } else {
+        result.notice = newSrdObj<Spp::Notices::UnknownSymbolNotice>();
+      }
+    }
+
+    if (result.notice != 0) result.notice->setSourceLocation(Core::Data::Ast::findSourceLocation(
+      request.ref != 0 ? request.ref : request.astNode
+    ));
+  }
+}
+
+
+void CalleeTracer::_lookupCallee_routing(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result)
+{
+  PREPARE_SELF(tracer, CalleeTracer);
+  auto helper = tracer->helper;
+
+  if (request.target != 0 && request.target->isDerivedFrom<Ast::Function>()) {
+    tracer->lookupCallee_function(request, result);
+  } else if (request.target != 0 && request.target->isDerivedFrom<Type>()) {
+    if (request.targetIsObject) {
+      auto funcType = helper->tryGetPointerContentType<FunctionType>(request.target);
+      if (funcType != 0) {
+        tracer->lookupCallee_funcPtr(request, result);
+      } else {
+        if (ti_cast<UserType>(request.target) != 0) {
+          tracer->lookupCallee_customOp(request, result);
+          if (result.isSuccessful()) return;
+        }
+        tracer->lookupCallee_builtInOp(request, result);
+      }
+    } else {
+      tracer->lookupCallee_type(request, result);
+    }
+  } else if (request.target != 0 && request.target->isDerivedFrom<Template>()) {
+    tracer->lookupCallee_template(request, result);
+  } else if (request.target != 0 && helper->isAstReference(request.target)) {
+    tracer->lookupCallee_var(request, result);
+  } else {
+    // Invalid
+    if (result.notice == 0) result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
+  }
+}
+
+
+void CalleeTracer::_lookupCallee_function(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result)
+{
+  PREPARE_SELF(tracer, CalleeTracer);
+  auto helper = tracer->helper;
+
+  ContainerExtender<TiObject, 1, 0> extTypes(request.argTypes);
+  extTypes.setPreItem(0, request.thisType);
+
+  auto func = static_cast<Ast::Function*>(request.target);
+
+  if (request.op != "()") {
+    // Only allow this check if the funciton has the proper modifier.
+    // TODO: Check function modifiers rather than generic def modifiers.
+    auto def = func->findOwner<Core::Data::Ast::Definition>();
+    if (def == 0) return;
+    if (!helper->doesModifierExistOnDef(def, S("assign"))) return;
+  }
+
+  Bool useThis = !func->getType()->isBindDisabled() && request.thisType != 0;
+
+  result.matchStatus = func->getType()->matchCall(useThis ? &extTypes : request.argTypes, helper, request.ec);
+  if (result.matchStatus >= TypeMatchStatus::CUSTOM_CASTER) {
+    result.notice.reset();
+    result.stack.clear();
+    result.stack.add(func);
+    result.thisIndex = useThis ? -1 : -2;
+    result.type = func->getType().get();
+  } else {
+    result.notice = newSrdObj<Spp::Notices::ArgsMismatchNotice>();
+  }
+}
+
+
+void CalleeTracer::_lookupCallee_type(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result)
+{
+  PREPARE_SELF(tracer, CalleeTracer);
+  auto helper = tracer->helper;
+
+  auto type = static_cast<Type*>(request.target);
+
+  if (request.op == S("()")) {
+    // This is a constructor.
+    Function *customCaster;
+    static Core::Data::Ast::Identifier ref({ {S("value"), TiStr(S("~init"))} });
+    CalleeLookupRequest innerRequest = request;
+    innerRequest.ref = &ref;
+    innerRequest.target = type;
+    innerRequest.searchTargetOwners = false;
+    innerRequest.thisType = helper->getReferenceTypeFor(type, Ast::ReferenceMode::IMPLICIT);
+    tracer->lookupCallee(innerRequest, result);
+    if (result.isSuccessful()) {
+      // A constructor match was found.
+      result.pushStack(type);
+      result.thisIndex = -2;
+      result.type = type;
+    } else if (
+      request.argTypes->getElementCount() == 0 &&
+      (type->getInitializationMethod(helper, request.ec) & TypeInitMethod::USER) == 0
+    ) {
+      // No user-defined constructor is defined and no params is provided, so we can skip the matching.
+      result.matchStatus = TypeMatchStatus::EXACT;
+      result.notice.reset();
+      result.stack.clear();
+      result.stack.add(type);
+      result.thisIndex = -2;
+      result.type = type;
+    } else if (
+      (type->getInitializationMethod(helper, request.ec) & TypeInitMethod::USER) == 0 &&
+      request.argTypes->getElementCount() == 1 &&
+      helper->matchTargetType(request.argTypes->getElement(0), type, request.ec, customCaster) >= TypeMatchStatus::CUSTOM_CASTER
+    ) {
+      // A type with no custom init but can be initialized from the given arg.
+      result.matchStatus = TypeMatchStatus::EXACT;
+      result.notice.reset();
+      result.stack.clear();
+      result.stack.add(type);
+      result.thisIndex = -2;
+      result.type = type;
+    } else {
+      // If the ref symbol we provided here was not found we'll provide a better error message to the user since
+      // the user didn't manually provide this symbol.
+      if (result.notice != 0 && result.notice->isA<Spp::Notices::UnknownSymbolNotice>()) {
+        result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
+      }
+    }
+  } else {
+    result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
+  }
+}
+
+
+void CalleeTracer::_lookupCallee_template(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result)
+{
+  PREPARE_SELF(tracer, CalleeTracer);
+
+  // TODO: Look-up template functions as well.
+  auto objType = tracer->helper->traceType(request.target);
+  if (objType == 0) {
+    result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
+  } else {
+    CalleeLookupRequest innerRequest = request;
+    innerRequest.target = objType;
+    tracer->lookupCallee_routing(innerRequest, result);
+  }
+}
+
+
+void CalleeTracer::_lookupCallee_var(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result)
+{
+  PREPARE_SELF(tracer, CalleeTracer);
+  auto helper = tracer->helper;
+
+  auto def = Core::Data::findOwner<Core::Data::Ast::Definition>(ti_cast<Core::Data::Node>(request.target));
+  if (def == 0) {
+    throw EXCEPTION(GenericException, S("Unexpected error while looking for var definition."));
+  }
+  auto objType = ti_cast<Type>(helper->traceType(request.target));
+  if (objType == 0) {
+    result.notice = newSrdObj<Spp::Notices::InvalidTypeNotice>(Core::Data::Ast::findSourceLocation(request.target));
+    return;
+  }
+  objType = helper->tryGetDeepReferenceContentType(objType);
+  if (objType == 0) {
+    result.notice = newSrdObj<Spp::Notices::InvalidTypeNotice>(Core::Data::Ast::findSourceLocation(request.target));
+    return;
+  }
+
+  Bool noBindDef = helper->isNoBindDef(def);
+
+  CalleeLookupRequest innerRequest = request;
+  innerRequest.targetIsObject = true;
+  innerRequest.target = objType;
+  if (!noBindDef && objType->isDerivedFrom<UserType>()) {
+    innerRequest.thisType = helper->getReferenceTypeFor(objType, ReferenceMode::IMPLICIT);
+  }
+  tracer->lookupCallee_routing(innerRequest, result);
+
+  if (result.isSuccessful()) {
+    result.pushStack(request.target);
+    if (result.thisIndex == -1) {
+      result.thisIndex = (noBindDef || !objType->isDerivedFrom<UserType>()) ? -1 : 0;
+    }
+  }
+}
+
+
+void CalleeTracer::_lookupCallee_funcPtr(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result)
+{
+  PREPARE_SELF(tracer, CalleeTracer);
+  auto helper = tracer->helper;
+
+  ContainerExtender<TiObject, 1, 0> extTypes(request.argTypes);
+  extTypes.setPreItem(0, request.thisType);
+
+  auto funcType = helper->tryGetPointerContentType<FunctionType>(request.target);
+
+  // TODO: Verify op against modifier.
+  Bool useThis = !funcType->isBindDisabled() && request.thisType != 0;
+
+  result.matchStatus = funcType->matchCall(useThis ? &extTypes : request.argTypes, helper, request.ec);
+  if (result.matchStatus >= TypeMatchStatus::CUSTOM_CASTER) {
+    result.notice.reset();
+    result.stack.clear();
+    result.thisIndex = useThis ? -1 : -2;
+    result.type = funcType;
+  } else {
+    result.notice = newSrdObj<Spp::Notices::ArgsMismatchNotice>();
+  }
+}
+
+
+void CalleeTracer::_lookupCallee_customOp(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result)
+{
+  PREPARE_SELF(tracer, CalleeTracer);
+
+  Core::Data::Ast::Identifier ref({ {S("value"), TiStr(request.op)} });
+  CalleeLookupRequest innerRequest = request;
+  innerRequest.ref = &ref;
+  innerRequest.searchTargetOwners = false;
+  tracer->lookupCallee(innerRequest, result);
+  if (!result.isSuccessful()) {
+    // If the ref symbol we provided here was not found we'll provide a better error message to the user since
+    // the user didn't manually provide this symbol.
+    if (result.notice != 0 && result.notice->isA<Spp::Notices::UnknownSymbolNotice>()) {
+      result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
+    }
+  }
+}
+
+
+void CalleeTracer::_lookupCallee_builtInOp(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result)
+{
+  PREPARE_SELF(tracer, CalleeTracer);
+  auto helper = tracer->helper;
+
+  ContainerExtender<TiObject, 1, 0> extTypes(request.argTypes);
+  extTypes.setPreItem(0, request.thisType);
+
+  auto type = static_cast<Type*>(request.target);
+
+  if (request.op == S("()")) {
+    // Type must be an array for () operator.
+    if (type->isDerivedFrom<ArrayType>()) {
+      // We have an array.
+      if (
+        request.argTypes != 0 && request.argTypes->getElementCount() == 1 &&
+        helper->isImplicitlyCastableTo(request.argTypes->getElement(0), helper->getArchIntType(), request.ec)
+      ) {
+        result.matchStatus = TypeMatchStatus::EXACT;
+        result.type = type;
+        result.thisIndex = -2;
+        result.stack.clear();
+        result.notice.reset();
+      } else {
+        if (result.notice == 0) result.notice = newSrdObj<Spp::Notices::ArgsMismatchNotice>();
+      }
+    } else {
+      if (result.notice == 0) result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
+    }
+  } else if (request.op == S("=")) {
+    // Type must be castable to the target type for assignment operators.
+    if (request.argTypes != 0 && request.argTypes->getElementCount() == 1) {
+      Function *caster;
+      auto ms = helper->matchTargetType(request.argTypes->getElement(0), type, request.ec, caster);
+      if (ms >= TypeMatchStatus::CUSTOM_CASTER) {
+        result.matchStatus = ms;
+        result.type = type;
+        result.thisIndex = -2;
+        result.stack.clear();
+        result.notice.reset();
+      } else {
+        if (result.notice == 0) result.notice = newSrdObj<Spp::Notices::ArgsMismatchNotice>();
+      }
+    } else {
+      if (result.notice == 0) result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
+    }
+  } else {
+    // Accept any other operator and let the caller handle the built in type checking.
+    result.matchStatus = TypeMatchStatus::EXACT;
+    result.type = type;
+    result.thisIndex = -2;
+    result.stack.clear();
+    result.notice.reset();
+  }
+}
+
+
+// TODO:
+Bool CalleeTracer::_lookupReferenceTarget(
+  TiObject *self, TiObject *astNode, Core::Data::Ast::Identifier *ref, Bool searchOwners, PlainList<TiObject> &stack
+) {
+  PREPARE_SELF(tracer, CalleeTracer);
+
+  Word currentStackSize = stack.getCount();
+  Bool symbolFound = false;
+  tracer->getSeeker()->foreach(ref, astNode,
+    [=, &symbolFound, &stack] (TiObject *obj, Core::Notices::Notice*)->Core::Data::Seeker::Verb
+    {
+      symbolFound = true;
+      stack.add(obj);
+      return Core::Data::Seeker::Verb::STOP;
+    },
+    searchOwners ? 0 : SeekerExtension::Flags::SKIP_OWNERS_AND_USES
+  );
+
+  if (!symbolFound) {
+    Block *block = 0;
+    auto dataType = ti_cast<DataType>(astNode);
+    if (dataType != 0) block = dataType->getBody().get();
+    else block = Core::Data::findOwner<Block>(ti_cast<Core::Data::Node>(astNode));
+
+    if (block != 0) {
+      for (Int i = 0; i < block->getInjectionCount(); ++i) {
+        auto def = ti_cast<Core::Data::Ast::Definition>(block->getInjection(i));
+        if (def == 0 || def->getTarget() == 0) continue;
+        if (!tracer->helper->isAstReference(def->getTarget().get())) continue;
+        auto objType = ti_cast<Type>(tracer->getSeeker()->tryGet(def->getTarget().get(), block));
+        if (objType == 0) continue;
+        objType = tracer->helper->tryGetDeepReferenceContentType(objType);
+        stack.add(def->getTarget().get());
+        if (tracer->lookupReferenceTarget(objType, ref, false, stack)) {
+          symbolFound = true;
+          break;
+        } else {
+          while (stack.getCount() > currentStackSize) stack.remove(currentStackSize);
+        }
+      }
+    }
+  }
+
+  return symbolFound;
+}
+
+
+//==============================================================================
+// Helper Functions
+
+void CalleeTracer::selectBetterResult(CalleeLookupResult const &newResult, CalleeLookupResult &result)
+{
+  if (newResult.matchStatus >= TypeMatchStatus::CUSTOM_CASTER) {
+    // It was a successful match.
+    if (newResult.matchStatus > result.matchStatus) {
+      // Better result is found.
+      result = newResult;
+    } else if (newResult.matchStatus == result.matchStatus) {
+      // Multiple callee match.
+      result.notice = newSrdObj<Spp::Notices::MultipleCalleeMatchNotice>();
+    }
+  } else if (result.matchStatus == TypeMatchStatus::NONE && result.notice == 0) {
+    // It was a failed match and we don't have a previous failed match, so we'll take this match.
+    result = newResult;
+  }
+}
+
+} // namespace

--- a/Sources/Spp/Ast/CalleeTracer.cpp
+++ b/Sources/Spp/Ast/CalleeTracer.cpp
@@ -63,9 +63,9 @@ void CalleeTracer::_lookupCallee(TiObject *self, CalleeLookupRequest &request, C
 
   if (request.ref != 0) {
     auto target = request.target;
-    int tracingAlias = 0;
+    Int tracingAlias = 0;
     auto callback = [=, &request, &result, &target, &tracingAlias]
-      (Core::Data::Seeker::Action action, TiObject *obj)->Core::Data::Seeker::Verb
+      (TiInt action, TiObject *obj)->Core::Data::Seeker::Verb
       {
         if (action == Core::Data::Seeker::Action::ERROR) {
           if (result.isNew()) result.notice = getSharedPtr(ti_cast<Core::Notices::Notice>(obj));
@@ -193,13 +193,14 @@ void CalleeTracer::_lookupCallee(TiObject *self, CalleeLookupRequest &request, C
             // an infinite loop.
             if (bridgeRef->getTarget() == request.ref) continue;
             auto bridgeTarget = tracer->getSeeker()->tryGet(
-              bridgeRef->getTarget().get(), scope, Core::Data::Seeker::Flags::SKIP_USES
+              bridgeRef->getTarget().get(), scope,
+              Core::Data::Seeker::Flags::SKIP_USES | Core::Data::Seeker::Flags::SKIP_USES_FOR_ALIASES
             );
             if (bridgeTarget == 0) continue;
 
             tracingAlias = 0;
             auto verb = tracer->getSeeker()->foreach(request.ref, bridgeTarget, callback, 0);
-            if (verb == Core::Data::Seeker::Verb::STOP) break;
+            if (!Core::Data::Seeker::isMove(verb)) break;
           }
         }
       }

--- a/Sources/Spp/Ast/CalleeTracer.h
+++ b/Sources/Spp/Ast/CalleeTracer.h
@@ -113,10 +113,25 @@ class CalleeTracer : public TiObject, public DynamicBinding, public DynamicInter
   );
   private: static void _lookupCallee_template(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result);
 
+  public: METHOD_BINDING_CACHE(lookupCallee_scope,
+    void, (CalleeLookupRequest& /* request */, CalleeLookupResult& /* result */)
+  );
+  private: static void _lookupCallee_scope(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result);
+
+  public: METHOD_BINDING_CACHE(lookupCallee_argPack,
+    void, (CalleeLookupRequest& /* request */, CalleeLookupResult& /* result */)
+  );
+  private: static void _lookupCallee_argPack(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result);
+
   public: METHOD_BINDING_CACHE(lookupCallee_var,
     void, (CalleeLookupRequest& /* request */, CalleeLookupResult& /* result */)
   );
   private: static void _lookupCallee_var(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result);
+
+  public: METHOD_BINDING_CACHE(lookupCallee_literal,
+    void, (CalleeLookupRequest& /* request */, CalleeLookupResult& /* result */)
+  );
+  private: static void _lookupCallee_literal(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result);
 
   public: METHOD_BINDING_CACHE(lookupCallee_funcPtr,
     void, (CalleeLookupRequest& /* request */, CalleeLookupResult& /* result */)
@@ -133,19 +148,14 @@ class CalleeTracer : public TiObject, public DynamicBinding, public DynamicInter
   );
   private: static void _lookupCallee_builtInOp(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result);
 
-  public: METHOD_BINDING_CACHE(lookupReferenceTarget,
-    Bool, (TiObject*, Core::Data::Ast::Identifier*, Bool, PlainList<TiObject>&)
-  );
-  private: static Bool _lookupReferenceTarget(
-    TiObject *self, TiObject *astNode, Core::Data::Ast::Identifier *ref, Bool searchOwners, PlainList<TiObject> &stack
-  );
-
   /// @}
 
   /// @name Helper Functions
   /// @{
 
   private: static void selectBetterResult(CalleeLookupResult const &newResult, CalleeLookupResult &result);
+
+  private: static Char const* findOperationModifier(Core::Data::Ast::Definition *def);
 
   /// @}
 

--- a/Sources/Spp/Ast/CalleeTracer.h
+++ b/Sources/Spp/Ast/CalleeTracer.h
@@ -1,0 +1,156 @@
+/**
+ * @file Spp/Ast/CalleeTracer.h
+ * Contains the header of class Spp::Ast::CalleeTracer.
+ *
+ * @copyright Copyright (C) 2021 Sarmad Khalid Abdullah
+ *
+ * @license This file is released under Alusus Public License, Version 1.0.
+ * For details on usage and copying conditions read the full license in the
+ * accompanying license file or at <https://alusus.org/license.html>.
+ */
+//==============================================================================
+
+#ifndef SPP_AST_CALLEETRACER_H
+#define SPP_AST_CALLEETRACER_H
+
+namespace Spp::Ast
+{
+
+class CalleeTracer : public TiObject, public DynamicBinding, public DynamicInterfacing
+{
+  //============================================================================
+  // Type Info
+
+  TYPE_INFO(CalleeTracer, TiObject, "Spp.Ast", "Spp", "alusus.org", (
+    INHERITANCE_INTERFACES(DynamicBinding, DynamicInterfacing),
+    OBJECT_INTERFACE_LIST(interfaceList)
+  ));
+
+
+  //============================================================================
+  // Member Variables
+
+  private: Helper *helper;
+
+
+  //============================================================================
+  // Implementations
+
+  IMPLEMENT_DYNAMIC_BINDINGS(bindingMap);
+  IMPLEMENT_DYNAMIC_INTERFACING(interfaceList);
+
+
+  //============================================================================
+  // Constructor
+
+  CalleeTracer(Helper *h) : helper(h)
+  {
+    this->initBindingCaches();
+    this->initBindings();
+  }
+
+  CalleeTracer(CalleeTracer *parent)
+  {
+    this->initBindingCaches();
+    this->inheritBindings(parent);
+    this->inheritInterfaces(parent);
+    this->helper = parent->getHelper();
+  }
+
+
+  //============================================================================
+  // Member Functions
+
+  /// @name Initialization
+  /// @{
+
+  private: void initBindingCaches();
+
+  private: void initBindings();
+
+  /// @}
+
+  /// @name Property Getters
+  /// @{
+
+  public: Helper* getHelper() const
+  {
+    return this->helper;
+  }
+
+  public: Core::Data::Seeker* getSeeker() const
+  {
+    return this->helper->getSeeker();
+  }
+
+  /// @}
+
+  /// @name Main Functions
+  /// @{
+
+  public: METHOD_BINDING_CACHE(lookupCallee,
+    void, (CalleeLookupRequest& /* request */, CalleeLookupResult& /* result */)
+  );
+  private: static void _lookupCallee(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result);
+
+  public: METHOD_BINDING_CACHE(lookupCallee_routing,
+    void, (CalleeLookupRequest& /* request */, CalleeLookupResult& /* result */)
+  );
+  private: static void _lookupCallee_routing(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result);
+
+  public: METHOD_BINDING_CACHE(lookupCallee_function,
+    void, (CalleeLookupRequest& /* request */, CalleeLookupResult& /* result */)
+  );
+  private: static void _lookupCallee_function(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result);
+
+  public: METHOD_BINDING_CACHE(lookupCallee_type,
+    void, (CalleeLookupRequest& /* request */, CalleeLookupResult& /* result */)
+  );
+  private: static void _lookupCallee_type(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result);
+
+  public: METHOD_BINDING_CACHE(lookupCallee_template,
+    void, (CalleeLookupRequest& /* request */, CalleeLookupResult& /* result */)
+  );
+  private: static void _lookupCallee_template(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result);
+
+  public: METHOD_BINDING_CACHE(lookupCallee_var,
+    void, (CalleeLookupRequest& /* request */, CalleeLookupResult& /* result */)
+  );
+  private: static void _lookupCallee_var(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result);
+
+  public: METHOD_BINDING_CACHE(lookupCallee_funcPtr,
+    void, (CalleeLookupRequest& /* request */, CalleeLookupResult& /* result */)
+  );
+  private: static void _lookupCallee_funcPtr(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result);
+
+  public: METHOD_BINDING_CACHE(lookupCallee_customOp,
+    void, (CalleeLookupRequest& /* request */, CalleeLookupResult& /* result */)
+  );
+  private: static void _lookupCallee_customOp(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result);
+
+  public: METHOD_BINDING_CACHE(lookupCallee_builtInOp,
+    void, (CalleeLookupRequest& /* request */, CalleeLookupResult& /* result */)
+  );
+  private: static void _lookupCallee_builtInOp(TiObject *self, CalleeLookupRequest &request, CalleeLookupResult &result);
+
+  public: METHOD_BINDING_CACHE(lookupReferenceTarget,
+    Bool, (TiObject*, Core::Data::Ast::Identifier*, Bool, PlainList<TiObject>&)
+  );
+  private: static Bool _lookupReferenceTarget(
+    TiObject *self, TiObject *astNode, Core::Data::Ast::Identifier *ref, Bool searchOwners, PlainList<TiObject> &stack
+  );
+
+  /// @}
+
+  /// @name Helper Functions
+  /// @{
+
+  private: static void selectBetterResult(CalleeLookupResult const &newResult, CalleeLookupResult &result);
+
+  /// @}
+
+}; // class
+
+} // namespace
+
+#endif

--- a/Sources/Spp/Ast/CalleeTracer.h
+++ b/Sources/Spp/Ast/CalleeTracer.h
@@ -155,8 +155,6 @@ class CalleeTracer : public TiObject, public DynamicBinding, public DynamicInter
 
   private: static void selectBetterResult(CalleeLookupResult const &newResult, CalleeLookupResult &result);
 
-  private: static Char const* findOperationModifier(Core::Data::Ast::Definition *def);
-
   /// @}
 
 }; // class

--- a/Sources/Spp/Ast/FloatType.cpp
+++ b/Sources/Spp/Ast/FloatType.cpp
@@ -20,11 +20,12 @@ namespace Spp::Ast
 
 Word FloatType::getBitCount(Helper *helper) const
 {
-  if (this->bitCountRef == 0) {
-    this->bitCountRef = helper->getRootManager()->parseExpression(S("bitCount"));
+  static TioSharedPtr bitCountRef;
+  if (bitCountRef == 0) {
+    bitCountRef = helper->getRootManager()->parseExpression(S("bitCount"));
   }
   auto bitCount = ti_cast<Core::Data::Ast::IntegerLiteral>(
-    helper->getSeeker()->doGet(this->bitCountRef.get(), this->getOwner())
+    helper->getSeeker()->doGet(bitCountRef.get(), this->getOwner())
   );
   if (bitCount == 0) {
     throw EXCEPTION(GenericException, S("Could not find bitCount value."));

--- a/Sources/Spp/Ast/FloatType.h
+++ b/Sources/Spp/Ast/FloatType.h
@@ -28,12 +28,6 @@ class FloatType : public DataType
 
 
   //============================================================================
-  // Member Variables
-
-  private: mutable TioSharedPtr bitCountRef;
-
-
-  //============================================================================
   // Constructors & Destructor
 
   IMPLEMENT_EMPTY_CONSTRUCTOR(FloatType);

--- a/Sources/Spp/Ast/Helper.cpp
+++ b/Sources/Spp/Ast/Helper.cpp
@@ -116,10 +116,9 @@ TypeMatchStatus Helper::_lookupCustomCaster(
       PlainList<TiObject> argTypes({ srcRefType });
       static Core::Data::Ast::Identifier ref({{S("value"), TiStr(S("~cast"))}});
       TypeMatchStatus retMatch;
-      helper->getSeeker()->foreach(&ref, srcContentType->getBody().get(),
-        [=, &retMatch, &caster, &argTypes] (Core::Data::Seeker::Action action, TiObject *obj)->Core::Data::Seeker::Verb
+      helper->getSeeker()->extForeach(&ref, srcContentType->getBody().get(),
+        [=, &retMatch, &caster, &argTypes] (TiInt action, TiObject *obj)->Core::Data::Seeker::Verb
         {
-          if (action != Core::Data::Seeker::Action::TARGET_MATCH) return Core::Data::Seeker::Verb::MOVE;
           auto func = ti_cast<Function>(obj);
           if (func != 0) {
             auto funcType = func->getType().get();
@@ -136,7 +135,7 @@ TypeMatchStatus Helper::_lookupCustomCaster(
           }
           return Core::Data::Seeker::Verb::MOVE;
         },
-        SeekerExtension::Flags::SKIP_OWNERS_AND_USES
+        Core::Data::Seeker::Flags::SKIP_OWNERS | Core::Data::Seeker::Flags::SKIP_USES
       );
       return retMatch;
     }
@@ -181,7 +180,7 @@ Type* Helper::_traceType(TiObject *self, TiObject *ref)
       throw EXCEPTION(GenericException, S("Invalid type reference."));
     }
     helper->getSeeker()->foreach(typeRef, owner,
-      [=, &foundObj, &type, &notice](Core::Data::Seeker::Action action, TiObject *obj)->Core::Data::Seeker::Verb
+      [=, &foundObj, &type, &notice](TiInt action, TiObject *obj)->Core::Data::Seeker::Verb
       {
         if (action == Core::Data::Seeker::Action::ERROR) {
           notice = getSharedPtr(ti_cast<Core::Notices::Notice>(obj));
@@ -851,7 +850,7 @@ Bool Helper::_validateUseStatement(TiObject *self, Core::Data::Ast::Bridge *brid
   }
   Bool found = false;
   helper->getSeeker()->foreach(bridge->getTarget().get(), bridge->getOwner(),
-    [=, &found] (Core::Data::Seeker::Action action, TiObject *obj)->Core::Data::Seeker::Verb
+    [=, &found] (TiInt action, TiObject *obj)->Core::Data::Seeker::Verb
     {
       if (action != Core::Data::Seeker::Action::TARGET_MATCH) return Core::Data::Seeker::Verb::MOVE;
       if (ti_cast<Ast::Module>(obj) != 0) {

--- a/Sources/Spp/Ast/Helper.cpp
+++ b/Sources/Spp/Ast/Helper.cpp
@@ -170,6 +170,8 @@ Type* Helper::_traceType(TiObject *self, TiObject *ref)
       if (result != 0 && result->isDerivedFrom<Core::Notices::Notice>()) notice = result.s_cast<Core::Notices::Notice>();
     }
   } else if (helper->isAstReference(ref)) {
+    type = tryGetAstType(ref);
+    if (type != 0) return type;
     auto typeRef = static_cast<Core::Data::Node*>(ref);
     auto owner = typeRef->getOwner();
     auto paramPass = ti_cast<Core::Data::Ast::ParamPass>(ref);
@@ -222,6 +224,7 @@ Type* Helper::_traceType(TiObject *self, TiObject *ref)
         return Core::Data::Seeker::Verb::MOVE;
       }, 0
     );
+    if (type != 0) setAstType(ref, type);
   }
 
   if (type == 0 && helper->noticeStore != 0) {

--- a/Sources/Spp/Ast/Helper.cpp
+++ b/Sources/Spp/Ast/Helper.cpp
@@ -22,10 +22,7 @@ void Helper::initBindingCaches()
 {
   Basic::initBindingCaches(this, {
     &this->isAstReference,
-    &this->lookupCalleeInScope,
-    &this->lookupCalleeOnObject,
     &this->lookupCustomCaster,
-    &this->lookupReferenceTarget,
     &this->traceType,
     &this->isVoid,
     &this->isImplicitlyCastableTo,
@@ -61,10 +58,7 @@ void Helper::initBindingCaches()
 void Helper::initBindings()
 {
   this->isAstReference = &Helper::_isAstReference;
-  this->lookupCalleeInScope = &Helper::_lookupCalleeInScope;
-  this->lookupCalleeOnObject = &Helper::_lookupCalleeOnObject;
   this->lookupCustomCaster = &Helper::_lookupCustomCaster;
-  this->lookupReferenceTarget = &Helper::_lookupReferenceTarget;
   this->traceType = &Helper::_traceType;
   this->isVoid = &Helper::_isVoid;
   this->isImplicitlyCastableTo = &Helper::_isImplicitlyCastableTo;
@@ -110,311 +104,6 @@ Bool Helper::_isAstReference(TiObject *self, TiObject *obj)
 }
 
 
-Bool Helper::lookupCalleeInScopeByName(
-  Char const *name, SharedPtr<Core::Data::SourceLocation> const &sl, Core::Data::Node *astNode, Bool searchOwners,
-  TiObject *thisType, Containing<TiObject> *types, ExecutionContext const *ec, CalleeLookupResult &result
-) {
-  Core::Data::Ast::Identifier identifier;
-  identifier.setValue(name);
-  identifier.setSourceLocation(sl);
-  return this->lookupCalleeInScope(&identifier, astNode, searchOwners, thisType, types, ec, result);
-}
-
-
-Bool Helper::_lookupCalleeInScope(
-  TiObject *self, TiObject *ref, Core::Data::Node *astNode, Bool searchOwners,
-  TiObject *thisType, Containing<TiObject> *types, ExecutionContext const *ec, CalleeLookupResult &result
-) {
-  PREPARE_SELF(helper, Helper);
-
-  Word currentStackSize = result.stack.getLength();
-  Core::Data::Node *prevNode = 0;
-  Bool retVal = false;
-  helper->getSeeker()->foreach(ref, astNode,
-    [=, &result, &prevNode, &retVal]
-      (TiObject *obj, Core::Notices::Notice *ntc)->Core::Data::Seeker::Verb
-      {
-        if (ntc != 0) {
-          if (result.notice == 0 && result.stack.getLength() == currentStackSize) result.notice = getSharedPtr(ntc);
-          return Core::Data::Seeker::Verb::MOVE;
-        }
-        if (obj == 0) return Core::Data::Seeker::Verb::MOVE;
-
-        // Unbox if we have a box.
-        auto box = ti_cast<TioWeakBox>(obj);
-        if (box != 0) obj = box->get().get();
-
-        if (
-          result.stack.getLength() > 0 && result.stack(result.stack.getLength() - 1) == obj &&
-          result.thisIndex < 0
-        ) {
-          return Core::Data::Seeker::Verb::MOVE;
-        }
-
-        // There is no need to continue searching if we already have a match and we are jumping to another level.
-        auto node = ti_cast<Core::Data::Node>(obj);
-        if (node != 0 && prevNode != 0) {
-          // If we encounter the same node again it means we moved up and encountered a use statement that took us back
-          // into the same module. In this case we can stop looking since we have moved up and we already have a match.
-          if (node == prevNode) return Core::Data::Seeker::Verb::STOP;
-
-          // If it's not the same node, then let's check the owners of the two nodes.
-          Core::Data::Node *owner = Core::Data::findOwner<Core::Data::Ast::Scope>(node);
-          // It's possible that the previous match was for a function arg, so we have to account for that since a
-          // function arg would have the same owner scope as a function sitting at the same module.
-          Core::Data::Node *prevOwner = Core::Data::findOwner<Spp::Ast::FunctionType>(prevNode);
-          if (prevOwner == 0) prevOwner = Core::Data::findOwner<Core::Data::Ast::Scope>(prevNode);
-          if (owner != prevOwner) return Core::Data::Seeker::Verb::STOP;
-        }
-
-        if (helper->lookupCalleeOnObject(obj, thisType, types, ec, currentStackSize, result)) {
-          retVal = true;
-          prevNode = node;
-        } else {
-          if (result.notice != 0 && result.notice->isDerivedFrom<Spp::Notices::MultipleCalleeMatchNotice>()) {
-            retVal = false;
-            if (result.matchStatus == TypeMatchStatus::EXACT) {
-              // There is no need to continue searching if we found multiple exact matches.
-              return Core::Data::Seeker::Verb::STOP;
-            }
-          }
-        }
-
-        return Core::Data::Seeker::Verb::MOVE;
-      },
-      searchOwners ? 0 : SeekerExtension::Flags::SKIP_OWNERS_AND_USES
-  );
-
-  // Try the injections if we don't have an exact match yet.
-  if (result.matchStatus < TypeMatchStatus::EXACT) {
-    auto dataType = ti_cast<DataType>(astNode);
-    if (dataType != 0) {
-      auto block = dataType->getBody().get();
-      if (block != 0) {
-        Word newStackSize = result.stack.getLength();
-        for (Int i = 0; i < block->getInjectionCount(); ++i) {
-          auto def = ti_cast<Core::Data::Ast::Definition>(block->getInjection(i));
-          if (def == 0 || def->getTarget() == 0) continue;
-          if (!helper->isAstReference(def->getTarget().get())) continue;
-          Bool isMember = helper->getVariableDomain(def) == DefinitionDomain::OBJECT;
-          if ((isMember && thisType == 0) || (!isMember && thisType != 0)) continue;
-          auto objType = helper->traceType(def->getTarget().get());
-          if (objType == 0) continue;
-          auto refType = helper->getReferenceTypeFor(objType, Ast::ReferenceMode::IMPLICIT);
-          objType = helper->tryGetDeepReferenceContentType(objType);
-          result.stack.add(def->getTarget().get());
-          Bool noBindDef = helper->isNoBindDef(def);
-          if (helper->lookupCalleeInScope(ref, objType, false, noBindDef ? thisType : refType, types, ec, result)) {
-            retVal = true;
-            if (noBindDef) result.thisIndex = currentStackSize - 1;
-            if (result.matchStatus == TypeMatchStatus::EXACT) break;
-          } else {
-            while (result.stack.getLength() > newStackSize) result.stack.remove(newStackSize);
-          }
-        }
-      }
-    }
-  }
-
-  // Did we have a matched callee?
-  if (!retVal) {
-    // Remove any extra items we added to the stack.
-    while (result.stack.getLength() > currentStackSize) result.stack.remove(currentStackSize);
-
-    // If we have no notice it means the symbol was not found in the first place.
-    if (result.notice == 0 && result.matchStatus == TypeMatchStatus::NONE) {
-      result.notice = newSrdObj<Spp::Notices::UnknownSymbolNotice>();
-    }
-
-    if (result.notice != 0) result.notice->setSourceLocation(Core::Data::Ast::findSourceLocation(ref));
-  }
-
-  return retVal;
-}
-
-
-Bool Helper::_lookupCalleeOnObject(
-  TiObject *self, TiObject *obj, TiObject *thisType, Containing<TiObject> *types, ExecutionContext const *ec,
-  Word currentStackSize, CalleeLookupResult &result
-) {
-  PREPARE_SELF(helper, Helper);
-
-  ContainerExtender<TiObject, 1, 0> extTypes(types);
-  extTypes.setPreItem(0, thisType);
-
-  if (obj != 0 && obj->isDerivedFrom<Ast::Function>()) {
-    // Match functions.
-    auto f = static_cast<Ast::Function*>(obj);
-    TypeMatchStatus ms;
-
-    Bool useThis = !f->getType()->isBindDisabled() && thisType != 0;
-
-    ms = f->getType()->matchCall(useThis ? &extTypes : types, helper, ec);
-    if (ms < TypeMatchStatus::CUSTOM_CASTER && result.matchStatus == TypeMatchStatus::NONE) {
-      result.notice = newSrdObj<Spp::Notices::ArgsMismatchNotice>();
-      return false;
-    } else if (ms >= TypeMatchStatus::CUSTOM_CASTER && ms > result.matchStatus) {
-      result.matchStatus = ms;
-      result.notice.reset();
-      result.thisIndex = currentStackSize - 1;
-      if (result.stack.getLength() == currentStackSize) result.stack.add(f);
-      else result.stack(currentStackSize) = f;
-      result.type = f->getType().get();
-      return true;
-    } else if (ms >= TypeMatchStatus::CUSTOM_CASTER && ms == result.matchStatus) {
-      result.notice = newSrdObj<Spp::Notices::MultipleCalleeMatchNotice>();
-      return false;
-    } else {
-      return false;
-    }
-  } else if (obj != 0 && obj->isDerivedFrom<ArrayType>()) {
-    if (
-      types != 0 && types->getElementCount() == 1 &&
-      helper->isImplicitlyCastableTo(types->getElement(0), helper->getArchIntType(), ec)
-    ) {
-      if (result.matchStatus < TypeMatchStatus::EXACT) {
-        result.matchStatus = TypeMatchStatus::EXACT;
-        result.type = static_cast<ArrayType*>(obj);
-        result.notice.reset();
-        return true;
-      } else {
-        result.notice = newSrdObj<Spp::Notices::MultipleCalleeMatchNotice>();
-        return false;
-      }
-    } else {
-      if (result.matchStatus == TypeMatchStatus::NONE) {
-        result.notice = newSrdObj<Spp::Notices::ArgsMismatchNotice>();
-      }
-      return false;
-    }
-  } else if (obj != 0 && obj->isDerivedFrom<Type>()) {
-    auto funcType = helper->tryGetPointerContentType<FunctionType>(obj);
-    if (funcType != 0) {
-      // We have a function pointer.
-      Bool useThis = !funcType->isBindDisabled() && thisType != 0;
-      auto ms = funcType->matchCall(useThis ? &extTypes : types, helper, ec);
-      if (ms < TypeMatchStatus::CUSTOM_CASTER && result.matchStatus == TypeMatchStatus::NONE) {
-        result.notice = newSrdObj<Spp::Notices::ArgsMismatchNotice>();
-        return false;
-      } else if (ms >= TypeMatchStatus::CUSTOM_CASTER && ms > result.matchStatus) {
-        result.matchStatus = ms;
-        result.notice.reset();
-        result.thisIndex = useThis ? currentStackSize - 1 : -2;
-        result.type = funcType;
-        return true;
-      } else if (ms >= TypeMatchStatus::CUSTOM_CASTER && ms == result.matchStatus) {
-        result.notice = newSrdObj<Spp::Notices::MultipleCalleeMatchNotice>();
-        return false;
-      } else {
-        return false;
-      }
-    } else {
-      auto objType = static_cast<Type*>(obj);
-      auto objRefType = helper->getReferenceTypeFor(obj, Ast::ReferenceMode::IMPLICIT);
-      Function *customCaster;
-      if (result.stack.getLength() == currentStackSize && thisType == 0) {
-        // This is a constructor.
-        static Core::Data::Ast::Identifier ref({ {S("value"), TiStr(S("~init"))} });
-        if (helper->lookupCalleeInScope(
-          &ref, static_cast<Core::Data::Node*>(obj), false, objRefType, types, ec, result
-        )) {
-          // A constructor match was found.
-          result.stack(currentStackSize) = objType;
-          result.thisIndex = -2;
-          result.type = objType;
-          return true;
-        } else if (
-          types->getElementCount() == 0 && (objType->getInitializationMethod(helper, ec) & TypeInitMethod::USER) == 0
-        ) {
-          // No user-defined constructor is defined and no params is provided, so we can skip the matching.
-          result.matchStatus = TypeMatchStatus::EXACT;
-          result.notice.reset();
-          result.stack.add(objType);
-          result.thisIndex = -2;
-          result.type = objType;
-          return true;
-        } else if (
-          (objType->getInitializationMethod(helper, ec) & TypeInitMethod::USER) == 0 &&
-          types->getElementCount() == 1 &&
-          helper->matchTargetType(types->getElement(0), objType, ec, customCaster) >= TypeMatchStatus::CUSTOM_CASTER
-        ) {
-          // A type with no custom init but can be initialized from the given arg.
-          result.matchStatus = TypeMatchStatus::EXACT;
-          result.notice.reset();
-          result.stack.add(objType);
-          result.thisIndex = -2;
-          result.type = objType;
-          return true;
-        } else {
-          // If the ref symbol we provided here was not found we'll provide a better error message to the user since
-          // the user didn't manually provide this symbol.
-          if (result.notice != 0 && result.notice->isA<Spp::Notices::UnknownSymbolNotice>()) {
-            result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
-          }
-          return false;
-        }
-      } else {
-        // Lookup custom parens operators.
-        static Core::Data::Ast::Identifier ref({ {S("value"), TiStr(S("()"))} });
-        if (helper->lookupCalleeInScope(
-          &ref, static_cast<Core::Data::Node*>(obj), false, objRefType, types, ec, result
-        )) {
-          return true;
-        } else {
-          // If the ref symbol we provided here was not found we'll provide a better error message to the user since
-          // the user didn't manually provide this symbol.
-          if (result.notice != 0 && result.notice->isA<Spp::Notices::UnknownSymbolNotice>()) {
-            result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
-          }
-          return false;
-        }
-      }
-    }
-  } else if (obj != 0 && helper->isAstReference(obj)) {
-    // Match variables
-    auto objType = ti_cast<Type>(helper->traceType(obj));
-    if (objType == 0) return false;
-    objType = helper->tryGetDeepReferenceContentType(objType);
-    if (objType == 0) {
-      if (result.matchStatus == TypeMatchStatus::NONE) {
-        result.notice = newSrdObj<Spp::Notices::InvalidTypeNotice>(Core::Data::Ast::findSourceLocation(obj));
-      }
-      return false;
-    } else {
-      TiObject *prevVal = 0;
-      if (result.stack.getLength() == currentStackSize) result.stack.add(obj);
-      else {
-        prevVal = result.stack(currentStackSize);
-        result.stack(currentStackSize) = obj;
-      }
-      if (helper->lookupCalleeOnObject(objType, thisType, types, ec, currentStackSize, result)) {
-        return true;
-      } else {
-        if (result.stack.getLength() > currentStackSize) result.stack.remove(currentStackSize);
-        else result.stack(currentStackSize) = prevVal;
-        return false;
-      }
-    }
-  } else if (obj != 0 && obj->isDerivedFrom<Template>()) {
-    // TODO: Look-up template functions as well.
-    auto objType = helper->traceType(obj);
-    if (objType == 0) {
-      if (result.matchStatus == TypeMatchStatus::NONE) {
-        result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
-      }
-      return false;
-    }
-    return helper->lookupCalleeOnObject(objType, thisType, types, ec, currentStackSize, result);
-  } else {
-    // Invalid
-    if (result.matchStatus == TypeMatchStatus::NONE) {
-      result.notice = newSrdObj<Spp::Notices::InvalidOperationNotice>();
-    }
-    return false;
-  }
-}
-
-
 TypeMatchStatus Helper::_lookupCustomCaster(
   TiObject *self, Type *srcType, Type *targetType, ExecutionContext const *ec, Function *&caster
 ) {
@@ -428,8 +117,9 @@ TypeMatchStatus Helper::_lookupCustomCaster(
       static Core::Data::Ast::Identifier ref({{S("value"), TiStr(S("~cast"))}});
       TypeMatchStatus retMatch;
       helper->getSeeker()->foreach(&ref, srcContentType->getBody().get(),
-        [=, &retMatch, &caster, &argTypes] (TiObject *obj, Core::Notices::Notice *ntc)->Core::Data::Seeker::Verb
+        [=, &retMatch, &caster, &argTypes] (Core::Data::Seeker::Action action, TiObject *obj)->Core::Data::Seeker::Verb
         {
+          if (action != Core::Data::Seeker::Action::TARGET_MATCH) return Core::Data::Seeker::Verb::MOVE;
           auto func = ti_cast<Function>(obj);
           if (func != 0) {
             auto funcType = func->getType().get();
@@ -452,52 +142,6 @@ TypeMatchStatus Helper::_lookupCustomCaster(
     }
   }
   return TypeMatchStatus::NONE;
-}
-
-
-Bool Helper::_lookupReferenceTarget(
-  TiObject *self, TiObject *astNode, Core::Data::Ast::Identifier *ref, Bool searchOwners, PlainList<TiObject> &stack
-) {
-  PREPARE_SELF(helper, Helper);
-
-  Word currentStackSize = stack.getCount();
-  Bool symbolFound = false;
-  helper->getSeeker()->foreach(ref, astNode,
-    [=, &symbolFound, &stack] (TiObject *obj, Core::Notices::Notice*)->Core::Data::Seeker::Verb
-    {
-      symbolFound = true;
-      stack.add(obj);
-      return Core::Data::Seeker::Verb::STOP;
-    },
-    searchOwners ? 0 : SeekerExtension::Flags::SKIP_OWNERS_AND_USES
-  );
-
-  if (!symbolFound) {
-    Block *block = 0;
-    auto dataType = ti_cast<DataType>(astNode);
-    if (dataType != 0) block = dataType->getBody().get();
-    else block = Core::Data::findOwner<Block>(ti_cast<Core::Data::Node>(astNode));
-
-    if (block != 0) {
-      for (Int i = 0; i < block->getInjectionCount(); ++i) {
-        auto def = ti_cast<Core::Data::Ast::Definition>(block->getInjection(i));
-        if (def == 0 || def->getTarget() == 0) continue;
-        if (!helper->isAstReference(def->getTarget().get())) continue;
-        auto objType = ti_cast<Type>(helper->getSeeker()->tryGet(def->getTarget().get(), block));
-        if (objType == 0) continue;
-        objType = helper->tryGetDeepReferenceContentType(objType);
-        stack.add(def->getTarget().get());
-        if (helper->lookupReferenceTarget(objType, ref, false, stack)) {
-          symbolFound = true;
-          break;
-        } else {
-          while (stack.getCount() > currentStackSize) stack.remove(currentStackSize);
-        }
-      }
-    }
-  }
-
-  return symbolFound;
 }
 
 
@@ -537,10 +181,14 @@ Type* Helper::_traceType(TiObject *self, TiObject *ref)
       throw EXCEPTION(GenericException, S("Invalid type reference."));
     }
     helper->getSeeker()->foreach(typeRef, owner,
-      [=, &foundObj, &type, &notice](TiObject *obj, Core::Notices::Notice *ntc)->Core::Data::Seeker::Verb
+      [=, &foundObj, &type, &notice](Core::Data::Seeker::Action action, TiObject *obj)->Core::Data::Seeker::Verb
       {
-        if (ntc != 0) {
-          notice = getSharedPtr(ntc);
+        if (action == Core::Data::Seeker::Action::ERROR) {
+          notice = getSharedPtr(ti_cast<Core::Notices::Notice>(obj));
+          ASSERT(notice != 0);
+          return Core::Data::Seeker::Verb::MOVE;
+        }
+        if (action != Core::Data::Seeker::Action::TARGET_MATCH) {
           return Core::Data::Seeker::Verb::MOVE;
         }
 
@@ -566,7 +214,9 @@ Type* Helper::_traceType(TiObject *self, TiObject *ref)
               return Core::Data::Seeker::Verb::STOP;
             }
           } else {
-            if (result != 0 && result->isDerivedFrom<Core::Notices::Notice>()) notice = result.s_cast<Core::Notices::Notice>();
+            if (result != 0 && result->isDerivedFrom<Core::Notices::Notice>()) {
+              notice = result.s_cast<Core::Notices::Notice>();
+            }
           }
         }
 
@@ -1201,8 +851,9 @@ Bool Helper::_validateUseStatement(TiObject *self, Core::Data::Ast::Bridge *brid
   }
   Bool found = false;
   helper->getSeeker()->foreach(bridge->getTarget().get(), bridge->getOwner(),
-    [=, &found] (TiObject *obj, Core::Notices::Notice*)->Core::Data::Seeker::Verb
+    [=, &found] (Core::Data::Seeker::Action action, TiObject *obj)->Core::Data::Seeker::Verb
     {
+      if (action != Core::Data::Seeker::Action::TARGET_MATCH) return Core::Data::Seeker::Verb::MOVE;
       if (ti_cast<Ast::Module>(obj) != 0) {
         found = true;
         return Core::Data::Seeker::Verb::STOP;

--- a/Sources/Spp/Ast/Helper.h
+++ b/Sources/Spp/Ast/Helper.h
@@ -128,33 +128,6 @@ class Helper : public TiObject, public DynamicBinding, public DynamicInterfacing
   public: METHOD_BINDING_CACHE(isAstReference, Bool, (TiObject*));
   private: static Bool _isAstReference(TiObject *self, TiObject *obj);
 
-  public: Bool lookupCalleeInScopeByName(
-    Char const *name, SharedPtr<Core::Data::SourceLocation> const &sl, Core::Data::Node *astNode, Bool searchOwners,
-    TiObject *thisType, Containing<TiObject> *types, ExecutionContext const *ec, CalleeLookupResult &result
-  );
-
-  public: METHOD_BINDING_CACHE(lookupCalleeInScope,
-    Bool, (
-      TiObject* /* ref */, Core::Data::Node* /* astNode */, Bool /* searchOwners */,
-      TiObject* /* thisType */, Containing<TiObject>* /* types */, ExecutionContext const* /* ec */,
-      CalleeLookupResult& /* result */
-    )
-  );
-  private: static Bool _lookupCalleeInScope(
-    TiObject *self, TiObject *ref, Core::Data::Node *astNode, Bool searchOwners,
-    TiObject *thisType, Containing<TiObject> *types, ExecutionContext const *ec, CalleeLookupResult &result
-  );
-
-  public: METHOD_BINDING_CACHE(lookupCalleeOnObject,
-    Bool, (
-      TiObject*, TiObject*, Containing<TiObject>*, ExecutionContext const*, Word, CalleeLookupResult&
-    )
-  );
-  private: static Bool _lookupCalleeOnObject(
-    TiObject *self, TiObject *obj, TiObject *thisType, Containing<TiObject> *types, ExecutionContext const *ec,
-    Word currentStackSize, CalleeLookupResult &result
-  );
-
   public: METHOD_BINDING_CACHE(lookupCustomCaster,
     TypeMatchStatus, (
       Type* /* srcType */, Type* /* targetType */, ExecutionContext const* /* ec */, Function *& /* caster */
@@ -162,13 +135,6 @@ class Helper : public TiObject, public DynamicBinding, public DynamicInterfacing
   );
   private: static TypeMatchStatus _lookupCustomCaster(
     TiObject *self, Type *srcType, Type *targetType, ExecutionContext const *ec, Function *&caster
-  );
-
-  public: METHOD_BINDING_CACHE(lookupReferenceTarget,
-    Bool, (TiObject*, Core::Data::Ast::Identifier*, Bool, PlainList<TiObject>&)
-  );
-  private: static Bool _lookupReferenceTarget(
-    TiObject *self, TiObject *astNode, Core::Data::Ast::Identifier *ref, Bool searchOwners, PlainList<TiObject> &stack
   );
 
   public: METHOD_BINDING_CACHE(traceType, Type*, (TiObject*));

--- a/Sources/Spp/Ast/IntegerType.cpp
+++ b/Sources/Spp/Ast/IntegerType.cpp
@@ -22,11 +22,12 @@ Word IntegerType::getBitCount(Helper *helper, ExecutionContext const *ec) const
 {
   if (this->isNullLiteral()) return 1;
 
-  if (this->bitCountRef == 0) {
-    this->bitCountRef = helper->getRootManager()->parseExpression(S("bitCount"));
+  static TioSharedPtr bitCountRef;
+  if (bitCountRef == 0) {
+    bitCountRef = helper->getRootManager()->parseExpression(S("bitCount"));
   }
   auto bitCountText = ti_cast<Core::Data::Ast::IntegerLiteral>(
-    helper->getSeeker()->doGet(this->bitCountRef.get(), this->getOwner())
+    helper->getSeeker()->doGet(bitCountRef.get(), this->getOwner())
   );
   if (bitCountText == 0) {
     throw EXCEPTION(GenericException, S("Could not find bitCount value."));

--- a/Sources/Spp/Ast/IntegerType.h
+++ b/Sources/Spp/Ast/IntegerType.h
@@ -34,8 +34,6 @@ class IntegerType : public DataType
 
   private: TiBool withSign;
 
-  private: mutable TioSharedPtr bitCountRef;
-
 
   //============================================================================
   // Implementations

--- a/Sources/Spp/Ast/NodePathResolver.cpp
+++ b/Sources/Spp/Ast/NodePathResolver.cpp
@@ -78,6 +78,8 @@ void NodePathResolver::_resolveDefinition(
   resolver->resolve(def->getOwner(), helper, path);
   if (path.tellp() > 0) path << C('.');
   path << def->getName().get();
+  auto defOp = findOperationModifier(def);
+  if (defOp != 0 && def->getName() != defOp) path << defOp;
 }
 
 

--- a/Sources/Spp/Ast/PointerType.cpp
+++ b/Sources/Spp/Ast/PointerType.cpp
@@ -20,11 +20,12 @@ namespace Spp { namespace Ast
 
 Type* PointerType::getContentType(Helper *helper) const
 {
-  if (this->contentTypeRef == 0) {
-    this->contentTypeRef = helper->getRootManager()->parseExpression(S("type"));
+  static TioSharedPtr contentTypeRef;
+  if (contentTypeRef == 0) {
+    contentTypeRef = helper->getRootManager()->parseExpression(S("type"));
   }
   auto typeBox = ti_cast<TioWeakBox>(
-    helper->getSeeker()->doGet(this->contentTypeRef.get(), this->getOwner())
+    helper->getSeeker()->doGet(contentTypeRef.get(), this->getOwner())
   );
   if (typeBox == 0) return 0;
   auto type = typeBox->get().ti_cast_get<Spp::Ast::Type>();

--- a/Sources/Spp/Ast/PointerType.h
+++ b/Sources/Spp/Ast/PointerType.h
@@ -28,12 +28,6 @@ class PointerType : public DataType
 
 
   //============================================================================
-  // Member Variables
-
-  private: mutable TioSharedPtr contentTypeRef;
-
-
-  //============================================================================
   // Constructors & Destructor
 
   IMPLEMENT_EMPTY_CONSTRUCTOR(PointerType);

--- a/Sources/Spp/Ast/ReferenceType.cpp
+++ b/Sources/Spp/Ast/ReferenceType.cpp
@@ -20,11 +20,12 @@ namespace Spp::Ast
 
 Type* ReferenceType::getContentType(Helper *helper) const
 {
-  if (this->contentTypeRef == 0) {
-    this->contentTypeRef = helper->getRootManager()->parseExpression(S("type"));
+  static TioSharedPtr contentTypeRef;
+  if (contentTypeRef == 0) {
+    contentTypeRef = helper->getRootManager()->parseExpression(S("type"));
   }
   auto typeBox = ti_cast<TioWeakBox>(
-    helper->getSeeker()->doGet(this->contentTypeRef.get(), this->getOwner())
+    helper->getSeeker()->doGet(contentTypeRef.get(), this->getOwner())
   );
   if (typeBox == 0) return 0;
   auto type = typeBox->get().ti_cast_get<Spp::Ast::Type>();

--- a/Sources/Spp/Ast/ReferenceType.h
+++ b/Sources/Spp/Ast/ReferenceType.h
@@ -41,8 +41,6 @@ class ReferenceType : public DataType
 
   private: ReferenceMode mode;
 
-  private: mutable TioSharedPtr contentTypeRef;
-
 
   //============================================================================
   // Implementations

--- a/Sources/Spp/Ast/ast.cpp
+++ b/Sources/Spp/Ast/ast.cpp
@@ -1,0 +1,35 @@
+/**
+ * @file Spp/Ast/ast.cpp
+ *
+ * @copyright Copyright (C) 2021 Sarmad Khalid Abdullah
+ *
+ * @license This file is released under Alusus Public License, Version 1.0.
+ * For details on usage and copying conditions read the full license in the
+ * accompanying license file or at <https://alusus.org/license.html>.
+ */
+//==============================================================================
+
+#include "spp.h"
+
+namespace Spp::Ast
+{
+
+Char const* findOperationModifier(Core::Data::Ast::Definition const *def)
+{
+  auto modifiers = def->getModifiers().get();
+  if (modifiers != 0) {
+    for (Int i = 0; i < modifiers->getElementCount(); ++i) {
+      auto paramPass = ti_cast<Core::Data::Ast::ParamPass>(modifiers->getElement(i));
+      if (paramPass != 0) {
+        auto identifier = paramPass->getOperand().ti_cast_get<Core::Data::Ast::Identifier>();
+        if (identifier != 0 && identifier->getValue() == S("operation")) {
+          auto stringLiteral = paramPass->getParam().ti_cast_get<Core::Data::Ast::StringLiteral>();
+          if (stringLiteral != 0) return stringLiteral->getValue().get();
+        }
+      }
+    }
+  }
+  return 0;
+}
+
+}

--- a/Sources/Spp/Ast/ast.h
+++ b/Sources/Spp/Ast/ast.h
@@ -86,13 +86,45 @@ ti_s_enum(DefinitionDomain,
 );
 
 /// @ingroup spp_ast
+struct CalleeLookupRequest
+{
+  Core::Data::Node *astNode = 0;
+  TiObject *target = 0;
+  Bool targetIsObject = false;
+  Bool searchTargetOwners = false;
+  TiObject *ref = 0;
+  Str op;
+  TiObject *thisType = 0;
+  Containing<TiObject> *argTypes = 0;
+  ExecutionContext const *ec;
+};
+
+/// @ingroup spp_ast
 struct CalleeLookupResult
 {
   TypeMatchStatus matchStatus = TypeMatchStatus::NONE;
-  PlainList<TiObject> stack;
+  Array<TiObject*> stack;
   Type *type = 0;
   SharedPtr<Core::Notices::Notice> notice;
   Int thisIndex = -2;
+
+  Bool isSuccessful() const
+  {
+    return this->matchStatus >= TypeMatchStatus::CUSTOM_CASTER && this->notice == 0;
+  }
+  Bool isFailure() const
+  {
+    return this->notice != 0;
+  }
+  Bool isNew() const
+  {
+    return this->matchStatus == TypeMatchStatus::NONE && this->notice == 0;
+  }
+
+  void pushStack(TiObject *obj) {
+    this->stack.insert(0, obj);
+    if (this->thisIndex >= 0) ++this->thisIndex;
+  }
 };
 
 /// @ingroup spp_ast
@@ -109,6 +141,7 @@ s_enum(TypeInitMethod,
 //==============================================================================
 // Type Names
 
+DEFINE_TYPE_NAME(Spp::Ast::CalleeLookupRequest, "alusus.org/Spp/Spp.Ast.CalleeLookupRequest");
 DEFINE_TYPE_NAME(Spp::Ast::CalleeLookupResult, "alusus.org/Spp/Spp.Ast.CalleeLookupResult");
 
 
@@ -161,6 +194,7 @@ DEFINE_TYPE_NAME(Spp::Ast::CalleeLookupResult, "alusus.org/Spp/Spp.Ast.CalleeLoo
 
 // Helpers
 #include "Helper.h"
+#include "CalleeTracer.h"
 #include "NodePathResolver.h"
 #include "metadata_helpers.h"
 

--- a/Sources/Spp/Ast/ast.h
+++ b/Sources/Spp/Ast/ast.h
@@ -104,7 +104,6 @@ struct CalleeLookupResult
 {
   TypeMatchStatus matchStatus = TypeMatchStatus::NONE;
   Array<TiObject*> stack;
-  Type *type = 0;
   SharedPtr<Core::Notices::Notice> notice;
   Int thisIndex = -2;
 
@@ -119,6 +118,10 @@ struct CalleeLookupResult
   Bool isNew() const
   {
     return this->matchStatus == TypeMatchStatus::NONE && this->notice == 0;
+  }
+  Bool isNameMatched() const
+  {
+    return !this->isNew() && (this->notice == 0 || !this->notice->isA<Spp::Notices::UnknownSymbolNotice>());
   }
 
   void pushStack(TiObject *obj) {

--- a/Sources/Spp/Ast/ast.h
+++ b/Sources/Spp/Ast/ast.h
@@ -138,6 +138,12 @@ s_enum(TypeInitMethod,
   BOTH = 3
 );
 
+
+//==============================================================================
+// Functions
+
+Char const* findOperationModifier(Core::Data::Ast::Definition const *def);
+
 } // namespace
 
 

--- a/Sources/Spp/CodeGen/AstProcessor.cpp
+++ b/Sources/Spp/CodeGen/AstProcessor.cpp
@@ -156,9 +156,9 @@ Bool AstProcessor::_processParamPass(
     Ast::Macro *macro = 0;
     Ast::PointerType *pointerType = 0;
     astProcessor->astHelper->getSeeker()->foreach(paramPass->getOperand().get(), paramPass->getOwner(),
-      [=, &macro, &pointerType] (TiObject *obj, Core::Notices::Notice *ntc)->Core::Data::Seeker::Verb
+      [=, &macro, &pointerType] (Core::Data::Seeker::Action action, TiObject *obj)->Core::Data::Seeker::Verb
       {
-        if (ntc != 0) {
+        if (action != Core::Data::Seeker::Action::TARGET_MATCH) {
           return Core::Data::Seeker::Verb::MOVE;
         }
 

--- a/Sources/Spp/CodeGen/AstProcessor.cpp
+++ b/Sources/Spp/CodeGen/AstProcessor.cpp
@@ -156,7 +156,7 @@ Bool AstProcessor::_processParamPass(
     Ast::Macro *macro = 0;
     Ast::PointerType *pointerType = 0;
     astProcessor->astHelper->getSeeker()->foreach(paramPass->getOperand().get(), paramPass->getOwner(),
-      [=, &macro, &pointerType] (Core::Data::Seeker::Action action, TiObject *obj)->Core::Data::Seeker::Verb
+      [=, &macro, &pointerType] (TiInt action, TiObject *obj)->Core::Data::Seeker::Verb
       {
         if (action != Core::Data::Seeker::Action::TARGET_MATCH) {
           return Core::Data::Seeker::Verb::MOVE;

--- a/Sources/Spp/CodeGen/ExpressionGenerator.cpp
+++ b/Sources/Spp/CodeGen/ExpressionGenerator.cpp
@@ -235,7 +235,22 @@ Bool ExpressionGenerator::_generateIdentifier(
 
   PlainList<TiObject> paramAstTypes;
   GenResult thisResult;
-  return expGenerator->prepareCallee(astNode, &paramAstTypes, S(""), g, session, result, thisResult);
+  if (!expGenerator->prepareCallee(astNode, &paramAstTypes, S(""), g, session, result, thisResult)) return false;
+
+  if (thisResult.astType != 0 && result.astNode != 0 && result.astNode->isDerivedFrom<Ast::Function>()) {
+    auto func = static_cast<Ast::Function*>(result.astNode);
+    auto def = func->findOwner<Core::Data::Ast::Definition>();
+    auto op = def == 0 ? 0 : Ast::findOperationModifier(def);
+    if (op != 0 && SBSTR(op) == S("")) {
+      SharedList<TiObject> paramTgValues;
+      PlainList<TiObject> paramAstNodes;
+      return expGenerator->generateRoundParamPassOnCallee(
+        astNode, result, thisResult, &paramTgValues, &paramAstTypes, &paramAstNodes, g, session, result
+      );
+    }
+  }
+
+  return true;
 }
 
 
@@ -253,7 +268,22 @@ Bool ExpressionGenerator::_generateLinkOperator(
 
   PlainList<TiObject> paramAstTypes;
   GenResult thisResult;
-  return expGenerator->prepareCallee(astNode, &paramAstTypes, S(""), g, session, result, thisResult);
+  if (!expGenerator->prepareCallee(astNode, &paramAstTypes, S(""), g, session, result, thisResult)) return false;
+
+  if (thisResult.astType != 0 && result.astNode != 0 && result.astNode->isDerivedFrom<Ast::Function>()) {
+    auto func = static_cast<Ast::Function*>(result.astNode);
+    auto def = func->findOwner<Core::Data::Ast::Definition>();
+    auto op = def == 0 ? 0 : Ast::findOperationModifier(def);
+    if (op != 0 && SBSTR(op) == S("")) {
+      SharedList<TiObject> paramTgValues;
+      PlainList<TiObject> paramAstNodes;
+      return expGenerator->generateRoundParamPassOnCallee(
+        astNode, result, thisResult, &paramTgValues, &paramAstTypes, &paramAstNodes, g, session, result
+      );
+    }
+  }
+
+  return true;
 }
 
 
@@ -314,7 +344,8 @@ Bool ExpressionGenerator::_generateRoundParamPassOnCallee(
       paramTgValues->insert(0, thisArg.targetData);
     }
     if (!expGenerator->prepareFunctionParams(
-      static_cast<Ast::Function*>(callee.astNode)->getType().get(), g, session, paramAstNodes, paramAstTypes, paramTgValues
+      static_cast<Ast::Function*>(callee.astNode)->getType().get(), g, session,
+      paramAstNodes, paramAstTypes, paramTgValues
     )) return false;
     // Generate the function call.
     return expGenerator->generateFunctionCall(

--- a/Sources/Spp/CodeGen/ExpressionGenerator.h
+++ b/Sources/Spp/CodeGen/ExpressionGenerator.h
@@ -135,17 +135,6 @@ class ExpressionGenerator : public TiObject, public DynamicBinding, public Dynam
     TiObject *self, Core::Data::Ast::Identifier *astNode, Generation *g, Session *session, GenResult &result
   );
 
-  public: METHOD_BINDING_CACHE(generateScopeMemberReference,
-    Bool, (
-      TiObject* /* scope */, Core::Data::Ast::Identifier* /* astNode */, Bool /* searchOwners */,
-      Generation* /* g */, Session* /* session */, GenResult& /* result */
-    )
-  );
-  private: static Bool _generateScopeMemberReference(
-    TiObject *self, TiObject *scope, Core::Data::Ast::Identifier *astNode, Bool searchOwners,
-    Generation *g, Session *session, GenResult &result
-  );
-
   public: METHOD_BINDING_CACHE(generateLinkOperator,
     Bool, (
       Core::Data::Ast::LinkOperator* /* astNode */, Generation* /* g */,
@@ -489,6 +478,16 @@ class ExpressionGenerator : public TiObject, public DynamicBinding, public Dynam
   /// @name Inner Generation Functions
   /// @{
 
+  public: METHOD_BINDING_CACHE(generateReferenceToNonObjectMember,
+    Bool, (
+      TiObject* /* obj */, Core::Data::Node* /* astNode */,
+      Generation* /* g */, Session* /* session */, GenResult& /* result */
+    )
+  );
+  private: static Bool _generateReferenceToNonObjectMember(
+    TiObject *self, TiObject *obj, Core::Data::Node *astNode, Generation *g, Session *session, GenResult &result
+  );
+
   public: METHOD_BINDING_CACHE(generateVarReference,
     Bool, (
       TiObject* /* refAstNode */, TiObject* /* varAstNode */,
@@ -497,17 +496,6 @@ class ExpressionGenerator : public TiObject, public DynamicBinding, public Dynam
   );
   private: static Bool _generateVarReference(
     TiObject *self, TiObject *refAstNode, TiObject *varAstNode, Generation *g, Session *session, GenResult &result
-  );
-
-  public: METHOD_BINDING_CACHE(generateMemberReference,
-    Bool, (
-      TiObject* /* tgValue */, Ast::Type* /* astType */, Core::Data::Ast::Identifier* /* astNode */,
-      Generation* /* g */, Session* /* session */, GenResult& /* result */
-    )
-  );
-  private: static Bool _generateMemberReference(
-    TiObject *self, TiObject *tgValue, Ast::Type * astType, Core::Data::Ast::Identifier *astNode,
-    Generation *g, Session *session, GenResult &result
   );
 
   public: METHOD_BINDING_CACHE(generateMemberVarReference,
@@ -558,6 +546,17 @@ class ExpressionGenerator : public TiObject, public DynamicBinding, public Dynam
     SharedList<TiObject> *paramTgVals
   );
 
+  public: METHOD_BINDING_CACHE(prepareCallee,
+    Bool, (
+      Core::Data::Node* /* astNode */, Containing<TiObject>* /* argTypes */, Char const* /* op */,
+      Generation* /* g */, Session* /* session */, GenResult& /* calleeResult */, GenResult& /* thisResult */
+    )
+  );
+  private: static Bool _prepareCallee(
+    TiObject *self, Core::Data::Node *astNode, Containing<TiObject> *argTypes, Char const *op,
+    Generation *g, Session *session, GenResult &calleeResult, GenResult &thisResult
+  );
+
   public: METHOD_BINDING_CACHE(prepareCalleeLookupRequest,
     Bool, (
       TiObject* /* operand */, Generation* /* g */, Session* /* session */,
@@ -579,17 +578,6 @@ class ExpressionGenerator : public TiObject, public DynamicBinding, public Dynam
   private: static Bool _generateCalleeReferenceChain(
     TiObject *self, Ast::CalleeLookupResult const &calleeInfo, Core::Data::Node *astNode, GenResult const &prevResult,
     Generation *g, Session *session, GenResult &calleeResult, GenResult &thisResult
-  );
-
-  public: METHOD_BINDING_CACHE(generateReferenceChain,
-    Bool, (
-      PlainList<TiObject>& /* stack */, Core::Data::Node* /* astNode */, GenResult const& /* prevResult */,
-      Generation* /* g */, Session* /* session */, GenResult& /* calleeResult */
-    )
-  );
-  private: static Bool _generateReferenceChain(
-    TiObject *self, PlainList<TiObject> &stack, Core::Data::Node *astNode, GenResult const &prevResult,
-    Generation *g, Session *session, GenResult &calleeResult
   );
 
   public: METHOD_BINDING_CACHE(generateParams,

--- a/Sources/Spp/CodeGen/ExpressionGenerator.h
+++ b/Sources/Spp/CodeGen/ExpressionGenerator.h
@@ -38,6 +38,7 @@ class ExpressionGenerator : public TiObject, public DynamicBinding, public Dynam
   // Member Variables
 
   private: Ast::Helper *astHelper;
+  private: Ast::CalleeTracer *calleeTracer;
   private: SharedList<TiObject> *astLiteralRepo;
   private: Core::Notices::Store *noticeStore = 0;
 
@@ -45,8 +46,8 @@ class ExpressionGenerator : public TiObject, public DynamicBinding, public Dynam
   //============================================================================
   // Constructors & Destructor
 
-  public: ExpressionGenerator(Ast::Helper *h, SharedList<TiObject> *alr)
-    : astHelper(h), astLiteralRepo(alr)
+  public: ExpressionGenerator(Ast::Helper *h, Ast::CalleeTracer *t, SharedList<TiObject> *alr)
+    : astHelper(h), calleeTracer(t), astLiteralRepo(alr)
   {
     this->initBindingCaches();
     this->initBindings();
@@ -58,6 +59,7 @@ class ExpressionGenerator : public TiObject, public DynamicBinding, public Dynam
     this->inheritBindings(parent);
     this->inheritInterfaces(parent);
     this->astHelper = parent->getAstHelper();
+    this->calleeTracer = parent->getCalleeTracer();
     this->astLiteralRepo = parent->getAstLiteralRepo();
   }
 
@@ -78,6 +80,11 @@ class ExpressionGenerator : public TiObject, public DynamicBinding, public Dynam
   public: Ast::Helper* getAstHelper() const
   {
     return this->astHelper;
+  }
+
+  public: Ast::CalleeTracer* getCalleeTracer() const
+  {
+    return this->calleeTracer;
   }
 
   public: SharedList<TiObject>* getAstLiteralRepo() const
@@ -549,6 +556,17 @@ class ExpressionGenerator : public TiObject, public DynamicBinding, public Dynam
     TiObject *self, Spp::Ast::FunctionType *calleeType, Generation *g, Session *session,
     DynamicContaining<TiObject> *paramAstNodes, DynamicContaining<TiObject> *paramAstTypes,
     SharedList<TiObject> *paramTgVals
+  );
+
+  public: METHOD_BINDING_CACHE(prepareCalleeLookupRequest,
+    Bool, (
+      TiObject* /* operand */, Generation* /* g */, Session* /* session */,
+      GenResult& /* prevResult */, Ast::CalleeLookupRequest& /* calleeRequest */
+    )
+  );
+  private: static Bool _prepareCalleeLookupRequest(
+    TiObject *self, TiObject *operand, Generation *g, Session *session,
+    GenResult &prevResult, Ast::CalleeLookupRequest &calleeRequest
   );
 
   public: METHOD_BINDING_CACHE(generateCalleeReferenceChain,

--- a/Sources/Spp/CodeGen/Generator.cpp
+++ b/Sources/Spp/CodeGen/Generator.cpp
@@ -579,8 +579,8 @@ Bool Generator::_generateVarInitialization(
     Ast::CalleeLookupResult calleeResult;
     if (generator->astHelper->lookupCalleeInScope(
       &ref, varAstType, false, 0, paramAstTypes, session->getExecutionContext(), calleeResult
-    ) && calleeResult.stack.getCount() == 1) {
-      auto callee = calleeResult.stack.get(calleeResult.stack.getCount() - 1);
+    ) && calleeResult.stack.getLength() == 1) {
+      auto callee = calleeResult.stack(calleeResult.stack.getLength() - 1);
       // Prepare the arguments to send.
       if (!generator->getExpressionGenerator()->prepareFunctionParams(
         static_cast<Ast::Function*>(callee)->getType().get(), generation, session,
@@ -736,8 +736,8 @@ Bool Generator::_generateVarDestruction(
   Ast::CalleeLookupResult calleeResult;
   if (generator->astHelper->lookupCalleeInScope(
     &ref, varAstType, false, 0, &paramAstTypes, session->getExecutionContext(), calleeResult
-  ) && calleeResult.stack.getCount() == 1) {
-    auto callee = static_cast<Ast::Function*>(calleeResult.stack.get(calleeResult.stack.getCount() - 1));
+  ) && calleeResult.stack.getLength() == 1) {
+    auto callee = static_cast<Ast::Function*>(calleeResult.stack(calleeResult.stack.getLength() - 1));
     // Call the destructor.
     GenResult result;
     if (!generator->getExpressionGenerator()->generateFunctionCall(

--- a/Sources/Spp/CodeGen/Generator.h
+++ b/Sources/Spp/CodeGen/Generator.h
@@ -39,6 +39,7 @@ class Generator : public TiObject, public DynamicBinding, public DynamicInterfac
 
   private: Core::Main::RootManager *rootManager;
   private: Ast::Helper *astHelper;
+  private: Ast::CalleeTracer *calleeTracer;
   private: GlobalItemRepo *globalItemRepo;
   private: TypeGenerator *typeGenerator;
   private: CommandGenerator *commandGenerator;
@@ -55,6 +56,7 @@ class Generator : public TiObject, public DynamicBinding, public DynamicInterfac
   public: Generator(
     Core::Main::RootManager *manager,
     Ast::Helper *ah,
+    Ast::CalleeTracer *cTracer,
     GlobalItemRepo *vr,
     TypeGenerator *tg,
     CommandGenerator *cg,
@@ -62,6 +64,7 @@ class Generator : public TiObject, public DynamicBinding, public DynamicInterfac
   ) :
     rootManager(manager),
     astHelper(ah),
+    calleeTracer(cTracer),
     globalItemRepo(vr),
     typeGenerator(tg),
     commandGenerator(cg),
@@ -77,6 +80,7 @@ class Generator : public TiObject, public DynamicBinding, public DynamicInterfac
     this->inheritInterfaces(parent);
     this->rootManager = parent->getRootManager();
     this->astHelper = parent->getAstHelper();
+    this->calleeTracer = parent->getCalleeTracer();
     this->globalItemRepo = parent->getGlobalItemRepo();
     this->typeGenerator = parent->getTypeGenerator();
     this->commandGenerator = parent->getCommandGenerator();
@@ -114,6 +118,11 @@ class Generator : public TiObject, public DynamicBinding, public DynamicInterfac
   public: Ast::Helper* getAstHelper() const
   {
     return this->astHelper;
+  }
+
+  public: Ast::CalleeTracer* getCalleeTracer() const
+  {
+    return this->calleeTracer;
   }
 
   public: GlobalItemRepo* getGlobalItemRepo() const

--- a/Sources/Spp/CodeGen/TypeGenerator.cpp
+++ b/Sources/Spp/CodeGen/TypeGenerator.cpp
@@ -397,8 +397,22 @@ Bool TypeGenerator::_generateUserTypeAutoConstructor(
   auto body = astType->getBody().get();
   session->getEda()->setCodeGenData(body, tgContext);
 
+  TioSharedPtr thisTgVar;
+  if (!session->getTg()->generateLocalVariable(tgContext.get(), tgPtrType, S("this"), 0, thisTgVar)) return false;
+  TioSharedPtr thisTgVarRef;
+  if (!session->getTg()->generateVarReference(tgContext.get(), tgPtrType, thisTgVar.get(), thisTgVarRef)) {
+    return false;
+  }
+  TioSharedPtr assignTgRes;
+  if (!session->getTg()->generateAssign(
+    tgContext.get(), tgPtrType, args.get(0).get(), thisTgVarRef.get(), assignTgRes)
+  ) {
+    return false;
+  }
+  auto thisIndex = typeGenerator->addThisDefinition(body, astType, thisTgVar, &childSession);
+
   // Main loop.
-  for (Int i = 0; i < body->getCount(); ++i) {
+  for (Int i = 0; i < thisIndex; ++i) {
     auto obj = body->getElement(i);
     auto def = ti_cast<Core::Data::Ast::Definition>(obj);
     if (def != 0) {
@@ -421,6 +435,8 @@ Bool TypeGenerator::_generateUserTypeAutoConstructor(
   if (!childSession.getTg()->finishFunctionBody(tgFunc.get(), tgFuncType.get(), &args, tgContext.get())) {
     throw EXCEPTION(GenericException, S("Failed to finalize function body for type constructor."));
   }
+
+  body->remove(thisIndex);
 
   session->getEda()->removeCodeGenData(body);
 
@@ -897,6 +913,30 @@ Bool TypeGenerator::_getTypeAllocationSize(
 
 //==============================================================================
 // Helper Functions
+
+Int TypeGenerator::addThisDefinition(
+  Ast::Block *body, Ast::Type *astThisType, TioSharedPtr const &tgThis, Session *session
+) {
+  auto thisRef = Core::Data::Ast::ParamPass::create({
+    {S("type"), Core::Data::Ast::BracketType(Core::Data::Ast::BracketType::SQUARE)}
+  }, {
+    {S("operand"), Core::Data::Ast::Identifier::create({ {S("value"), TiStr(S("iref"))} })},
+    {S("param"), Ast::ThisTypeRef::create()}
+  });
+  auto def = Core::Data::Ast::Definition::create({
+    {S("name"), TiStr(S("this"))}
+  }, {
+    {S("target"), thisRef},
+    {S("modifiers"), Core::Data::Ast::List::create({}, {
+      Core::Data::Ast::Identifier::create({ {S("value"), TiStr(S("injection"))} }),
+      Core::Data::Ast::Identifier::create({ {S("value"), TiStr(S("shared"))} })
+    })}
+  });
+  session->getEda()->setCodeGenData(thisRef.get(), tgThis);
+  Ast::setAstType(thisRef.get(), this->astHelper->getReferenceTypeFor(astThisType, Ast::ReferenceMode::IMPLICIT));
+  return body->add(def);
+}
+
 
 Bool TypeGenerator::isInjection(Core::Data::Ast::Definition *def)
 {

--- a/Sources/Spp/CodeGen/TypeGenerator.h
+++ b/Sources/Spp/CodeGen/TypeGenerator.h
@@ -217,6 +217,10 @@ class TypeGenerator : public TiObject, public DynamicBinding, public DynamicInte
   /// @name Helper Functions
   /// @{
 
+  private: Int addThisDefinition(
+    Ast::Block *body, Ast::Type *astThisType, TioSharedPtr const &tgThis, Session *session
+  );
+
   private: static Bool isInjection(Core::Data::Ast::Definition *def);
 
   /// @}

--- a/Sources/Spp/GrammarFactory.cpp
+++ b/Sources/Spp/GrammarFactory.cpp
@@ -67,6 +67,7 @@ void GrammarFactory::createGrammar(Core::Main::RootManager *root) {
   this->set(S("root.Main.Def.modifierTranslations.مشترك"), TiStr::create(S("shared")));
   this->set(S("root.Main.Def.modifierTranslations.دون_ربط"), TiStr::create(S("no_bind")));
   this->set(S("root.Main.Def.modifierTranslations.حقنة"), TiStr::create(S("injection")));
+  this->set(S("root.Main.Def.modifierTranslations.عملية"), TiStr::create(S("operation")));
 
   // Create leading commands.
 
@@ -332,7 +333,8 @@ void GrammarFactory::createGrammar(Core::Main::RootManager *root) {
   this->set(S("root.Main.Function.modifierTranslations"), Map::create({}, {
     {S("تصدير"), TiStr::create(S("expname"))},
     {S("مشترك"), TiStr::create(S("shared"))},
-    {S("دون_ربط"), TiStr::create(S("no_bind"))}
+    {S("دون_ربط"), TiStr::create(S("no_bind"))},
+    {S("عملية"), TiStr::create(S("operation"))}
   }));
 
   // FuncSigExpression
@@ -793,6 +795,7 @@ void GrammarFactory::cleanGrammar(Core::Main::RootManager *root)
   this->remove(S("root.Main.Def.modifierTranslations.مشترك"));
   this->remove(S("root.Main.Def.modifierTranslations.دون_ربط"));
   this->remove(S("root.Main.Def.modifierTranslations.حقنة"));
+  this->remove(S("root.Main.Def.modifierTranslations.عملية"));
 
   // Remove commands from tilde commands list.
   this->removeProdsFromGroup(S("root.Main.PostfixTildeCmdGrp"), {

--- a/Sources/Spp/Handlers/TypeHandlersParsingHandler.h
+++ b/Sources/Spp/Handlers/TypeHandlersParsingHandler.h
@@ -42,16 +42,21 @@ class TypeHandlersParsingHandler : public Core::Processing::Handlers::GenericPar
 
   private: void createAssignmentHandler(
     Processing::ParserState *state, Core::Data::Ast::AssignmentOperator *assignmentOp,
-    SharedPtr<Core::Data::Ast::Scope> const &body
+    SharedPtr<Core::Data::Ast::Scope> const &body, TioSharedPtr const &retType
   );
 
   private: void createComparisonHandler(
     Processing::ParserState *state, Core::Data::Ast::ComparisonOperator *comparisonOp,
-    SharedPtr<Core::Data::Ast::Scope> const &body
+    SharedPtr<Core::Data::Ast::Scope> const &body, TioSharedPtr const &retType
   );
 
   private: void createInfixOpHandler(
     Processing::ParserState *state, Core::Data::Ast::InfixOperator *infixOp,
+    SharedPtr<Core::Data::Ast::Scope> const &body, TioSharedPtr const &retType
+  );
+
+  private: void createReadHandler(
+    Processing::ParserState *state, Core::Data::Ast::LinkOperator *linkOp,
     SharedPtr<Core::Data::Ast::Scope> const &body, TioSharedPtr const &retType
   );
 
@@ -76,8 +81,8 @@ class TypeHandlersParsingHandler : public Core::Processing::Handlers::GenericPar
   );
 
   private: SharedPtr<Core::Data::Ast::Definition> createBinaryOpFunction(
-    Processing::ParserState *state, Char const *funcName, TioSharedPtr const &thisType, Char const *inputName,
-    TioSharedPtr const &inputType, TioSharedPtr const &retType, TioSharedPtr const &body,
+    Processing::ParserState *state, Char const *funcName, Char const *op, TioSharedPtr const &thisType,
+    Char const *inputName, TioSharedPtr const &inputType, TioSharedPtr const &retType, TioSharedPtr const &body,
     SharedPtr<Core::Data::SourceLocation> const &sourceLocation
   );
 

--- a/Sources/Spp/Handlers/TypeHandlersParsingHandler.h
+++ b/Sources/Spp/Handlers/TypeHandlersParsingHandler.h
@@ -82,8 +82,9 @@ class TypeHandlersParsingHandler : public Core::Processing::Handlers::GenericPar
   );
 
   private: SharedPtr<Core::Data::Ast::Definition> createFunction(
-    Processing::ParserState *state, Char const *funcName, SharedPtr<Core::Data::Ast::Map> const argTypes,
-    TioSharedPtr const &retType, TioSharedPtr const &body, SharedPtr<Core::Data::SourceLocation> const &sourceLocation
+    Processing::ParserState *state, Char const *funcName, Char const *op,
+    SharedPtr<Core::Data::Ast::Map> const argTypes, TioSharedPtr const &retType, TioSharedPtr const &body,
+    SharedPtr<Core::Data::SourceLocation> const &sourceLocation
   );
 
   private: Bool prepareInputArg(
@@ -103,7 +104,7 @@ class TypeHandlersParsingHandler : public Core::Processing::Handlers::GenericPar
   );
 
   private: SharedPtr<Core::Data::Ast::Definition> createDefinition(
-    Char const *funcName, SharedPtr<Spp::Ast::Function> func,
+    Char const *funcName, Char const *op, SharedPtr<Spp::Ast::Function> func,
     SharedPtr<Core::Data::SourceLocation> const &sourceLocation
   );
 

--- a/Sources/Spp/LibraryGateway.cpp
+++ b/Sources/Spp/LibraryGateway.cpp
@@ -44,6 +44,7 @@ void LibraryGateway::initialize(Main::RootManager *manager)
   this->generator = newSrdObj<CodeGen::Generator>(
     manager,
     this->astHelper.get(),
+    this->calleeTracer.get(),
     this->globalItemRepo.get(),
     this->typeGenerator.get(),
     this->commandGenerator.get(),

--- a/Sources/Spp/LibraryGateway.cpp
+++ b/Sources/Spp/LibraryGateway.cpp
@@ -27,6 +27,7 @@ void LibraryGateway::initialize(Main::RootManager *manager)
   // Create AST helpers.
   this->nodePathResolver = newSrdObj<Ast::NodePathResolver>();
   this->astHelper = newSrdObj<Ast::Helper>(manager, this->nodePathResolver.get());
+  this->calleeTracer = newSrdObj<Ast::CalleeTracer>(this->astHelper.get());
 
   // Create global repos.
   this->astLiteralRepo = newSrdObj<SharedList<TiObject>>();
@@ -36,6 +37,7 @@ void LibraryGateway::initialize(Main::RootManager *manager)
   this->typeGenerator = newSrdObj<CodeGen::TypeGenerator>(this->astHelper.get());
   this->expressionGenerator = newSrdObj<CodeGen::ExpressionGenerator>(
     this->astHelper.get(),
+    this->calleeTracer.get(),
     this->astLiteralRepo.get()
   );
   this->commandGenerator = newSrdObj<CodeGen::CommandGenerator>(this->astHelper.get());

--- a/Sources/Spp/LibraryGateway.h
+++ b/Sources/Spp/LibraryGateway.h
@@ -30,6 +30,7 @@ class LibraryGateway : public Core::Main::LibraryGateway
   private: RootScopeHandlerExtension::Overrides *rootScopeHandlerExtensionOverrides = 0;
   private: RootManagerExtension::Overrides *rootManagerExtensionOverrides = 0;
   private: SharedPtr<Ast::Helper> astHelper;
+  private: SharedPtr<Ast::CalleeTracer> calleeTracer;
   private: SharedPtr<Ast::NodePathResolver> nodePathResolver;
   private: SharedPtr<CodeGen::GlobalItemRepo> globalItemRepo;
   private: SharedPtr<SharedList<TiObject>> astLiteralRepo;

--- a/Sources/Spp/Rt/AstMgr.cpp
+++ b/Sources/Spp/Rt/AstMgr.cpp
@@ -86,10 +86,10 @@ Array<TiObject*> AstMgr::_findElements(TiObject *self, TiObject *ref, TiObject *
     }
     ref = scope->getElement(0);
   }
-  astMgr->rootManager->getSeeker()->foreach(ref, target,
-    [&result](Core::Data::Seeker::Action action, TiObject *obj)->Core::Data::Seeker::Verb
+  astMgr->rootManager->getSeeker()->extForeach(ref, target,
+    [&result](TiInt action, TiObject *obj)->Core::Data::Seeker::Verb
     {
-      if (action == Core::Data::Seeker::Action::TARGET_MATCH && obj != 0) result.add(obj);
+      if (obj != 0) result.add(obj);
       return Core::Data::Seeker::Verb::MOVE;
     },
     flags

--- a/Sources/Spp/Rt/AstMgr.cpp
+++ b/Sources/Spp/Rt/AstMgr.cpp
@@ -87,9 +87,9 @@ Array<TiObject*> AstMgr::_findElements(TiObject *self, TiObject *ref, TiObject *
     ref = scope->getElement(0);
   }
   astMgr->rootManager->getSeeker()->foreach(ref, target,
-    [&result](TiObject *obj, Core::Notices::Notice *notice)->Core::Data::Seeker::Verb
+    [&result](Core::Data::Seeker::Action action, TiObject *obj)->Core::Data::Seeker::Verb
     {
-      if (obj != 0) result.add(obj);
+      if (action == Core::Data::Seeker::Action::TARGET_MATCH && obj != 0) result.add(obj);
       return Core::Data::Seeker::Verb::MOVE;
     },
     flags

--- a/Sources/Spp/SeekerExtension.cpp
+++ b/Sources/Spp/SeekerExtension.cpp
@@ -127,7 +127,7 @@ Core::Data::Seeker::Verb SeekerExtension::_foreachByIdentifier_function(
   auto argTypes = function->getType()->getArgTypes().get();
   if (argTypes == 0) return Core::Data::Seeker::Verb::MOVE;
   auto index = argTypes->findIndex(identifier->getValue().get());
-  if (index >= 0) return cb(argTypes->getElement(index), 0);
+  if (index >= 0) return cb(Core::Data::Seeker::Action::TARGET_MATCH, argTypes->getElement(index));
   return Core::Data::Seeker::Verb::MOVE;
 }
 
@@ -175,9 +175,11 @@ Core::Data::Seeker::Verb SeekerExtension::_foreachByParamPass(
   PREPARE_SELF(seekerExtension, SeekerExtension);
   auto operand = paramPass->getOperand().get();
   return seeker->foreach(operand, data,
-    [=](TiObject *newData, Core::Notices::Notice*)->Core::Data::Seeker::Verb
+    [=](Core::Data::Seeker::Action action, TiObject *newData)->Core::Data::Seeker::Verb
     {
-      return seekerExtension->foreachByParamPass_routing(paramPass, newData, cb, flags);
+      if (action == Core::Data::Seeker::Action::TARGET_MATCH) {
+        return seekerExtension->foreachByParamPass_routing(paramPass, newData, cb, flags);
+      } else return cb(action, newData);
     },
     flags
   );
@@ -197,7 +199,7 @@ Core::Data::Seeker::Verb SeekerExtension::_foreachByParamPass_routing(
       auto notice = newSrdObj<Spp::Notices::InvalidSquareBracketOperandNotice>(
         Core::Data::Ast::findSourceLocation(paramPass)
       );
-      return cb(0, notice.get());
+      return cb(Core::Data::Seeker::Action::ERROR, notice.get());
     }
   } else {
     throw EXCEPTION(InvalidArgumentException, S("paramPass"), S("Invalid bracket type."), paramPass->getType());
@@ -211,10 +213,10 @@ Core::Data::Seeker::Verb SeekerExtension::_foreachByParamPass_template(
   PREPARE_SELF(seekerExtension, SeekerExtension);
   TioSharedPtr result;
   if (tmplt->matchInstance(param, seekerExtension->astHelper, result)) {
-    return cb(result.get(), 0);
+    return cb(Core::Data::Seeker::Action::TARGET_MATCH, result.get());
   } else {
     auto notice = result.ti_cast_get<Core::Notices::Notice>();
-    if (notice != 0) return cb(0, notice);
+    if (notice != 0) return cb(Core::Data::Seeker::Action::ERROR, notice);
     else return Core::Data::Seeker::Verb::MOVE;
   }
 }
@@ -226,7 +228,7 @@ Core::Data::Seeker::Verb SeekerExtension::_foreachByThisTypeRef(
   auto node = static_cast<Core::Data::Node*>(data);
   while (node != 0) {
     if (node->isDerivedFrom<Spp::Ast::DataType>()) {
-      return cb(node, 0);
+      return cb(Core::Data::Seeker::Action::TARGET_MATCH, node);
     }
     node = node->getOwner();
   }
@@ -244,12 +246,24 @@ Core::Data::Seeker::Verb SeekerExtension::_foreachByComparison(
     for (Int i = stack->getCount() - 1; i >= 0; --i) {
       auto data = stack->getElement(i);
       if (data == 0) continue;
+      if (i != stack->getCount() - 1) {
+        retVal = cb(Core::Data::Seeker::Action::OWNER_SCOPE, data);
+        if (retVal == Core::Data::Seeker::Verb::SKIP) continue;
+        else if (retVal == Core::Data::Seeker::Verb::SKIP_GROUP || retVal == Core::Data::Seeker::Verb::STOP) break;
+      }
       retVal = seekerExtension->foreachByComparison_level(comparison, data, cb, flags);
       if (!Core::Data::Seeker::isMove(retVal)) return retVal;
     }
   } else if (data->isDerivedFrom<Core::Data::Node>()) {
     auto node = static_cast<Core::Data::Node*>(data);
     while (node != 0) {
+      if (node != data) {
+        retVal = cb(Core::Data::Seeker::Action::OWNER_SCOPE, node);
+        if (retVal == Core::Data::Seeker::Verb::SKIP) {
+          node = node->getOwner();
+          continue;
+        } else if (retVal == Core::Data::Seeker::Verb::SKIP_GROUP || retVal == Core::Data::Seeker::Verb::STOP) break;
+      }
       retVal = seekerExtension->foreachByComparison_level(comparison, node, cb, flags);
       if (!Core::Data::Seeker::isMove(retVal)) return retVal;
       if (flags & Core::Data::Seeker::Flags::SKIP_OWNERS) break;
@@ -292,7 +306,7 @@ Core::Data::Seeker::Verb SeekerExtension::_foreachByComparison_scope(
     if (def != 0) {
       auto obj = def->getTarget().get();
       if (seekerExtension->foreachByComparison_compute(comparison, obj)) {
-        verb = cb(obj, 0);
+        verb = cb(Core::Data::Seeker::Action::TARGET_MATCH, obj);
         if (!Core::Data::Seeker::isMove(verb)) return verb;
       }
       if (!(flags & Flags::SKIP_CHILDREN)) {
@@ -303,18 +317,21 @@ Core::Data::Seeker::Verb SeekerExtension::_foreachByComparison_scope(
   }
 
   if (!(flags & Core::Data::Seeker::Flags::SKIP_USES)) {
+    verb = cb(Core::Data::Seeker::Action::USE_SCOPES_START, scope);
+    if (verb == Core::Data::Seeker::Verb::SKIP) return verb;
     PREPARE_SELF(seeker, Core::Data::Seeker);
     for (Int i = 0; i < scope->getBridgeCount(); ++i) {
       auto bridgeRef = scope->getBridge(i);
-      verb = seeker->foreach(bridgeRef->getTarget().get(), scope,
-        [=](TiObject *o, Core::Notices::Notice*)->Core::Data::Seeker::Verb {
-          if (o != 0) return seekerExtension->foreachByComparison_level(comparison, o, cb, flags);
-          else return Core::Data::Seeker::Verb::MOVE;
-        },
-        flags | Core::Data::Seeker::Flags::SKIP_USES
-      );
+      auto bridgeTarget = seeker->tryGet(bridgeRef->getTarget().get(), scope, Core::Data::Seeker::Flags::SKIP_USES);
+      if (bridgeTarget == 0) continue;
+      verb = cb(Core::Data::Seeker::Action::USE_SCOPE, bridgeTarget);
+      if (verb == Core::Data::Seeker::Verb::SKIP) continue;
+      else if (verb == Core::Data::Seeker::Verb::SKIP_GROUP || verb == Core::Data::Seeker::Verb::STOP) break;
+
+      verb = seekerExtension->foreachByComparison_level(comparison, bridgeTarget, cb, flags);
       if (!Core::Data::Seeker::isMove(verb)) return verb;
     }
+    verb = cb(Core::Data::Seeker::Action::USE_SCOPES_END, scope);
   }
 
   return verb;

--- a/Sources/Spp/SeekerExtension.cpp
+++ b/Sources/Spp/SeekerExtension.cpp
@@ -28,6 +28,7 @@ SeekerExtension::Overrides* SeekerExtension::extend(Core::Data::Seeker *seeker, 
   auto overrides = new Overrides();
   extension->astHelper = astHelper;
   overrides->foreachRef = seeker->foreach.set(&SeekerExtension::_foreach).get();
+  overrides->extForeachRef = seeker->extForeach.set(&SeekerExtension::_extForeach).get();
   overrides->foreachByIdentifier_levelRef =
     seeker->foreachByIdentifier_level.set(&SeekerExtension::_foreachByIdentifier_level).get();
   overrides->foreachByIdentifier_functionRef =
@@ -61,6 +62,7 @@ void SeekerExtension::unextend(Core::Data::Seeker *seeker, Overrides *overrides)
 {
   auto extension = ti_cast<SeekerExtension>(seeker);
   seeker->foreach.reset(overrides->foreachRef);
+  seeker->extForeach.reset(overrides->extForeachRef);
   seeker->foreachByIdentifier_level.reset(overrides->foreachByIdentifier_levelRef);
   seeker->foreachByLinkOperator_routing.reset(overrides->foreachByLinkOperator_routingRef);
   extension->astHelper = SharedPtr<Ast::Helper>::null;
@@ -100,6 +102,40 @@ Core::Data::Seeker::Verb SeekerExtension::_foreach(
     PREPARE_SELF(seeker, Core::Data::Seeker);
     return seeker->foreach.useCallee(base)(ref, target, cb, flags);
   }
+}
+
+
+Core::Data::Seeker::Verb SeekerExtension::_extForeach(
+  TiFunctionBase *base, TiObject *self, TiObject const *ref, TiObject *target,
+  Core::Data::Seeker::ForeachCallback const &cb, Word flags
+) {
+  PREPARE_SELF(seeker, Core::Data::Seeker);
+  Int tracingAlias = 0;
+  return seeker->foreach(ref, target, [flags, cb, &tracingAlias](TiInt action, TiObject *o)->Core::Data::Seeker::Verb {
+    if (action == Core::Data::Seeker::Action::ALIAS_TRACE_START) {
+      ++tracingAlias;
+      return Core::Data::Seeker::Verb::MOVE;
+    } else if (action == Core::Data::Seeker::Action::ALIAS_TRACE_END) {
+      --tracingAlias;
+      return Core::Data::Seeker::Verb::MOVE;
+    } else if (action == Core::Data::Seeker::Action::OWNER_SCOPE) {
+      if (tracingAlias == 0 && (flags & Core::Data::Seeker::Flags::SKIP_OWNERS) != 0) {
+        return Core::Data::Seeker::Verb::SKIP_GROUP;
+      } else return Core::Data::Seeker::Verb::MOVE;
+    } else if (action == Core::Data::Seeker::Action::USE_SCOPES_START) {
+      if (
+        (flags & Core::Data::Seeker::Flags::SKIP_USES) != 0 &&
+        (tracingAlias == 0 || (flags & Core::Data::Seeker::Flags::SKIP_USES_FOR_ALIASES) != 0)
+      ) {
+        return Core::Data::Seeker::Verb::SKIP;
+      } else return Core::Data::Seeker::Verb::MOVE;
+    } else if (action == SeekerExtension::Action::CHILD_SCOPE) {
+      if ((flags & SeekerExtension::Flags::SKIP_CHILDREN) != 0) return Core::Data::Seeker::Verb::SKIP;
+    } else if (action != Core::Data::Seeker::Action::TARGET_MATCH) {
+      return Core::Data::Seeker::Verb::MOVE;
+    }
+    return cb(action, o);
+  }, flags);
 }
 
 
@@ -175,7 +211,7 @@ Core::Data::Seeker::Verb SeekerExtension::_foreachByParamPass(
   PREPARE_SELF(seekerExtension, SeekerExtension);
   auto operand = paramPass->getOperand().get();
   return seeker->foreach(operand, data,
-    [=](Core::Data::Seeker::Action action, TiObject *newData)->Core::Data::Seeker::Verb
+    [=](TiInt action, TiObject *newData)->Core::Data::Seeker::Verb
     {
       if (action == Core::Data::Seeker::Action::TARGET_MATCH) {
         return seekerExtension->foreachByParamPass_routing(paramPass, newData, cb, flags);
@@ -249,7 +285,7 @@ Core::Data::Seeker::Verb SeekerExtension::_foreachByComparison(
       if (i != stack->getCount() - 1) {
         retVal = cb(Core::Data::Seeker::Action::OWNER_SCOPE, data);
         if (retVal == Core::Data::Seeker::Verb::SKIP) continue;
-        else if (retVal == Core::Data::Seeker::Verb::SKIP_GROUP || retVal == Core::Data::Seeker::Verb::STOP) break;
+        else if (retVal == Core::Data::Seeker::Verb::SKIP_GROUP || !Core::Data::Seeker::isMove(retVal)) break;
       }
       retVal = seekerExtension->foreachByComparison_level(comparison, data, cb, flags);
       if (!Core::Data::Seeker::isMove(retVal)) return retVal;
@@ -262,11 +298,10 @@ Core::Data::Seeker::Verb SeekerExtension::_foreachByComparison(
         if (retVal == Core::Data::Seeker::Verb::SKIP) {
           node = node->getOwner();
           continue;
-        } else if (retVal == Core::Data::Seeker::Verb::SKIP_GROUP || retVal == Core::Data::Seeker::Verb::STOP) break;
+        } else if (retVal == Core::Data::Seeker::Verb::SKIP_GROUP || !Core::Data::Seeker::isMove(retVal)) break;
       }
       retVal = seekerExtension->foreachByComparison_level(comparison, node, cb, flags);
       if (!Core::Data::Seeker::isMove(retVal)) return retVal;
-      if (flags & Core::Data::Seeker::Flags::SKIP_OWNERS) break;
       node = node->getOwner();
       flags |= Core::Data::Seeker::Flags::SKIP_OWNED;
     }
@@ -309,24 +344,28 @@ Core::Data::Seeker::Verb SeekerExtension::_foreachByComparison_scope(
         verb = cb(Core::Data::Seeker::Action::TARGET_MATCH, obj);
         if (!Core::Data::Seeker::isMove(verb)) return verb;
       }
-      if (!(flags & Flags::SKIP_CHILDREN)) {
+      verb = cb(SeekerExtension::Action::CHILD_SCOPE, obj);
+      if (verb != Core::Data::Seeker::Verb::SKIP) {
         verb = seekerExtension->foreachByComparison_level(comparison, obj, cb, flags);
-        if (!Core::Data::Seeker::isMove(verb)) return verb;
       }
+      if (!Core::Data::Seeker::isMove(verb)) return verb;
     }
   }
 
-  if (!(flags & Core::Data::Seeker::Flags::SKIP_USES)) {
+  if (scope->getBridgeCount() > 0) {
     verb = cb(Core::Data::Seeker::Action::USE_SCOPES_START, scope);
     if (verb == Core::Data::Seeker::Verb::SKIP) return verb;
     PREPARE_SELF(seeker, Core::Data::Seeker);
     for (Int i = 0; i < scope->getBridgeCount(); ++i) {
       auto bridgeRef = scope->getBridge(i);
-      auto bridgeTarget = seeker->tryGet(bridgeRef->getTarget().get(), scope, Core::Data::Seeker::Flags::SKIP_USES);
+      auto bridgeTarget = seeker->tryGet(
+        bridgeRef->getTarget().get(), scope,
+        Core::Data::Seeker::Flags::SKIP_USES | Core::Data::Seeker::Flags::SKIP_USES_FOR_ALIASES
+      );
       if (bridgeTarget == 0) continue;
       verb = cb(Core::Data::Seeker::Action::USE_SCOPE, bridgeTarget);
       if (verb == Core::Data::Seeker::Verb::SKIP) continue;
-      else if (verb == Core::Data::Seeker::Verb::SKIP_GROUP || verb == Core::Data::Seeker::Verb::STOP) break;
+      else if (verb == Core::Data::Seeker::Verb::SKIP_GROUP || !Core::Data::Seeker::isMove(verb)) break;
 
       verb = seekerExtension->foreachByComparison_level(comparison, bridgeTarget, cb, flags);
       if (!Core::Data::Seeker::isMove(verb)) return verb;

--- a/Sources/Spp/SeekerExtension.h
+++ b/Sources/Spp/SeekerExtension.h
@@ -30,6 +30,7 @@ class SeekerExtension : public ObjTiInterface
   public: struct Overrides
   {
     TiFunctionBase *foreachRef;
+    TiFunctionBase *extForeachRef;
     TiFunctionBase *foreachByIdentifier_levelRef;
     TiFunctionBase *foreachByIdentifier_functionRef;
     TiFunctionBase *foreachByIdentifier_dataTypeRef;
@@ -44,8 +45,11 @@ class SeekerExtension : public ObjTiInterface
     TiFunctionBase *foreachByComparison_computeRef;
   };
 
+  public: ti_s_enum(Action, TiInt, "Spp", "Spp", "alusus.org",
+    CHILD_SCOPE = 100
+  );
+
   public: s_enum(Flags,
-    SKIP_OWNERS_AND_USES = (Core::Data::Seeker::Flags::SKIP_OWNERS | Core::Data::Seeker::Flags::SKIP_USES),
     SKIP_CHILDREN = (1 << 16)
   );
 
@@ -113,6 +117,11 @@ class SeekerExtension : public ObjTiInterface
   /// @{
 
   private: static Core::Data::Seeker::Verb _foreach(
+    TiFunctionBase *base, TiObject *self, TiObject const *ref, TiObject *target,
+    Core::Data::Seeker::ForeachCallback const &cb, Word flags
+  );
+
+  private: static Core::Data::Seeker::Verb _extForeach(
     TiFunctionBase *base, TiObject *self, TiObject const *ref, TiObject *target,
     Core::Data::Seeker::ForeachCallback const &cb, Word flags
   );

--- a/Sources/Spp/spp.h
+++ b/Sources/Spp/spp.h
@@ -54,9 +54,9 @@ namespace Spp
 #include "DependencyInfo.h"
 #include "Executing.h"
 
-#include "Ast/ast.h"
-
 #include "Notices/notices.h"
+
+#include "Ast/ast.h"
 
 #include "CodeGen/code_gen.h"
 #include "LlvmCodeGen/llvm_code_gen.h"

--- a/Sources/Tests/Spp/Building/arrays_test.alusus.output
+++ b/Sources/Tests/Spp/Building/arrays_test.alusus.output
@@ -49,13 +49,13 @@ define [5 x i32] @"Main.getArray(Int[32])=>(array[Int[32],5])"(i32 %m) {
 
 "#block3":                                        ; preds = %"#block2"
   %2 = load i32, i32* %i
-  %3 = sext i32 %2 to i64
-  %4 = getelementptr [5 x i32], [5 x i32]* %a, i32 0, i64 %3
-  %5 = load i32, i32* %i
-  %6 = add nsw i32 %5, 1
-  %7 = load i32, i32* %m1
-  %8 = mul nsw i32 %6, %7
-  store i32 %8, i32* %4
+  %3 = add nsw i32 %2, 1
+  %4 = load i32, i32* %m1
+  %5 = mul nsw i32 %3, %4
+  %6 = load i32, i32* %i
+  %7 = sext i32 %6 to i64
+  %8 = getelementptr [5 x i32], [5 x i32]* %a, i32 0, i64 %7
+  store i32 %5, i32* %8
   %9 = load i32, i32* %i
   %10 = add nsw i32 %9, 1
   store i32 %10, i32* %i

--- a/Sources/Tests/Spp/Building/comparisons_test.alusus.output
+++ b/Sources/Tests/Spp/Building/comparisons_test.alusus.output
@@ -4,7 +4,7 @@ ERROR SPPG1015 @ (70,31): Incompatible types for the given operator.
 ERROR SPPG1015 @ (71,30): Incompatible types for the given operator.
 ERROR SPPG1015 @ (72,31): Incompatible types for the given operator.
 ERROR SPPG1015 @ (73,31): Incompatible types for the given operator.
-ERROR SPPG1008 @ (81,8): Invalid symbol.
+ERROR SPPG1002 @ (81,8): Invalid operation.
 Build Failed...
 --------------------- Partial LLVM IR ----------------------
 ; ModuleID = 'AlususProgram'

--- a/Sources/Tests/Spp/Building/custom_init_test.alusus.output
+++ b/Sources/Tests/Spp/Building/custom_init_test.alusus.output
@@ -213,13 +213,13 @@ define void @"A.~init(iref[A],ref[A])"(%A* %this, %A* %that) {
   %that2 = alloca %A*
   store %A* %that, %A** %that2
   %0 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([15 x i8], [15 x i8]* @"#anonymous4", i32 0, i32 0))
-  %1 = load %A*, %A** %this1
+  %1 = load %A*, %A** %that2
   %2 = getelementptr %A, %A* %1, i32 0, i32 0
-  %3 = load %A*, %A** %that2
-  %4 = getelementptr %A, %A* %3, i32 0, i32 0
-  %5 = load i32, i32* %4
-  %6 = mul nsw i32 %5, 2
-  store i32 %6, i32* %2
+  %3 = load i32, i32* %2
+  %4 = mul nsw i32 %3, 2
+  %5 = load %A*, %A** %this1
+  %6 = getelementptr %A, %A* %5, i32 0, i32 0
+  store i32 %4, i32* %6
   ret void
 }
 ------------------------------------------------------------
@@ -547,6 +547,8 @@ define void @"testAutoInit()"() {
 
 define void @B.__autoConstruct__(%B* %this) {
 "#block1":
+  %this1 = alloca %B*
+  store %B* %this, %B** %this1
   %0 = getelementptr %B, %B* %this, i32 0, i32 0
   call void @"A.~init(iref[A])"(%A* %0)
   %1 = getelementptr %B, %B* %this, i32 0, i32 1
@@ -612,9 +614,12 @@ define void @"testInlinedInit()"() {
 
 define void @C.__autoConstruct__(%C* %this) {
 "#block1":
+  %this1 = alloca %C*
+  store %C* %this, %C** %this1
   %0 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([16 x i8], [16 x i8]* @"#anonymous0", i32 0, i32 0))
-  %1 = getelementptr %C, %C* %this, i32 0, i32 0
-  store i32 3, i32* %1
+  %1 = load %C*, %C** %this1
+  %2 = getelementptr %C, %C* %1, i32 0, i32 0
+  store i32 3, i32* %2
   ret void
 }
 

--- a/Sources/Tests/Spp/Building/expressions_test.alusus.output
+++ b/Sources/Tests/Spp/Building/expressions_test.alusus.output
@@ -1,6 +1,6 @@
-ERROR SPPG1008 @ (145,19): Invalid symbol.
+ERROR SPPG1008 @ (145,28): Invalid symbol.
 ERROR SPPG1008 @ (146,23): Invalid symbol.
-ERROR SPPG1008 @ (147,19): Invalid symbol.
+ERROR SPPG1002 @ (147,19): Invalid operation.
 ERROR SPPG1015 @ (136,32): Incompatible types for the given operator.
 Build Failed...
 --------------------- Partial LLVM IR ----------------------

--- a/Sources/Tests/Spp/Building/injection_test.alusus.output
+++ b/Sources/Tests/Spp/Building/injection_test.alusus.output
@@ -59,16 +59,21 @@ define void @"test()"() {
 
 define void @Outer.__autoConstruct__(%Outer* %this) {
 "#block1":
-  %0 = getelementptr %Outer, %Outer* %this, i32 0, i32 0
-  %1 = getelementptr %Inner, %Inner* %0, i32 0, i32 0
-  %2 = load %InnerMost*, %InnerMost** %1
-  %3 = getelementptr %InnerMost, %InnerMost* %2, i32 0, i32 0
-  store i32 6, i32* %3
-  %4 = getelementptr %Outer, %Outer* %this, i32 0, i32 0
-  %5 = getelementptr %Inner, %Inner* %4, i32 0, i32 1
-  store i32 7, i32* %5
-  %6 = getelementptr %Outer, %Outer* %this, i32 0, i32 1
-  store i32 8, i32* %6
+  %this1 = alloca %Outer*
+  store %Outer* %this, %Outer** %this1
+  %0 = load %Outer*, %Outer** %this1
+  %1 = getelementptr %Outer, %Outer* %0, i32 0, i32 0
+  %2 = getelementptr %Inner, %Inner* %1, i32 0, i32 0
+  %3 = load %InnerMost*, %InnerMost** %2
+  %4 = getelementptr %InnerMost, %InnerMost* %3, i32 0, i32 0
+  store i32 6, i32* %4
+  %5 = load %Outer*, %Outer** %this1
+  %6 = getelementptr %Outer, %Outer* %5, i32 0, i32 0
+  %7 = getelementptr %Inner, %Inner* %6, i32 0, i32 1
+  store i32 7, i32* %7
+  %8 = load %Outer*, %Outer** %this1
+  %9 = getelementptr %Outer, %Outer* %8, i32 0, i32 1
+  store i32 8, i32* %9
   ret void
 }
 

--- a/Sources/Tests/Spp/Building/macros_test.alusus.output
+++ b/Sources/Tests/Spp/Building/macros_test.alusus.output
@@ -1,5 +1,21 @@
 ERROR SPPA1003 @ (7,38)
 from (63,5): No valid match was found for the given type.
+ERROR SPPA1003 @ (7,38)
+from (63,5): No valid match was found for the given type.
+ERROR SPPA1003 @ (7,38)
+from (63,5): No valid match was found for the given type.
+ERROR SPPA1003 @ (7,38)
+from (63,5): No valid match was found for the given type.
+ERROR SPPA1003 @ (7,38)
+from (63,5): No valid match was found for the given type.
+ERROR SPPA1003 @ (7,38)
+from (63,5): No valid match was found for the given type.
+ERROR SPPA1003 @ (7,38)
+from (63,5): No valid match was found for the given type.
+ERROR SPPA1003 @ (7,38)
+from (63,5): No valid match was found for the given type.
+ERROR SPPA1003 @ (7,38)
+from (63,5): No valid match was found for the given type.
 ERROR SPPG1037 @ (65,5): Incomplete infix operator. This is likely caused by a macro or a preprocess statement that evaluated to null.
 ERROR SPPG1038 @ (66,5): Incomplete prefix or postfix operator. This is likely caused by a macro or a preprocess statement that evaluated to null.
 ERROR SPPG1038 @ (67,5): Incomplete prefix or postfix operator. This is likely caused by a macro or a preprocess statement that evaluated to null.

--- a/Sources/Tests/Spp/Building/member_functions_test.alusus
+++ b/Sources/Tests/Spp/Building/member_functions_test.alusus
@@ -7,7 +7,7 @@ type A
   def i: Int;
 
   func print {
-    print("this.i = %d\n", this.i);
+    Root.print("this.i = %d\n", this.i);
   };
 
   func setI (i: Int) {

--- a/Sources/Tests/Spp/Building/member_functions_test.alusus.output
+++ b/Sources/Tests/Spp/Building/member_functions_test.alusus.output
@@ -3,7 +3,7 @@ ERROR SPPA1007 @ (97,13): Unknown symbol.
 ERROR SPPG1027 @ (75,3)
 from (99,10): Invalid redefinition of `this` in function args.
 ERROR SPPG1024 @ (100,3): Trying to access a local variable before it's initialized.
-ERROR SPPG1035 @ (102,5): The requested member is not a variable definition.
+ERROR SPPG1002 @ (102,5): Invalid operation.
 Build Failed...
 --------------------- Partial LLVM IR ----------------------
 ; ModuleID = 'AlususProgram'
@@ -171,12 +171,12 @@ define void @"B.~init(iref[B],ref[B])"(%B* %this, %B* %that) {
   store %B* %this, %B** %this1
   %that2 = alloca %B*
   store %B* %that, %B** %that2
-  %0 = load %B*, %B** %this1
+  %0 = load %B*, %B** %that2
   %1 = getelementptr %B, %B* %0, i32 0, i32 0
-  %2 = load %B*, %B** %that2
+  %2 = load %B*, %B** %this1
   %3 = getelementptr %B, %B* %2, i32 0, i32 0
-  %4 = load %A, %A* %3
-  store %A %4, %A* %1
+  %4 = load %A, %A* %1
+  store %A %4, %A* %3
   ret void
 }
 

--- a/Sources/Tests/Spp/Building/parameterized_ctors_test.alusus.output
+++ b/Sources/Tests/Spp/Building/parameterized_ctors_test.alusus.output
@@ -65,12 +65,12 @@ define void @"A.~init(iref[A],Int[32],ArgPack[Int[32],1,0])"(%A* %this, i32 %c, 
   br i1 %5, label %"#block5", label %"#block6"
 
 "#block5":                                        ; preds = %"#block4"
-  %6 = load %A*, %A** %this1
-  %7 = getelementptr %A, %A* %6, i32 0, i32 0
-  %8 = va_arg %__VaList* %__vaList, i32
-  %9 = load i32, i32* %7
-  %10 = add nsw i32 %9, %8
-  store i32 %10, i32* %7
+  %6 = va_arg %__VaList* %__vaList, i32
+  %7 = load %A*, %A** %this1
+  %8 = getelementptr %A, %A* %7, i32 0, i32 0
+  %9 = load i32, i32* %8
+  %10 = add nsw i32 %9, %6
+  store i32 %10, i32* %8
   br label %"#block4"
 
 "#block6":                                        ; preds = %"#block4"
@@ -81,6 +81,8 @@ define void @"A.~init(iref[A],Int[32],ArgPack[Int[32],1,0])"(%A* %this, i32 %c, 
 
 define void @B.__autoConstruct__(%B* %this) {
 "#block1":
+  %this1 = alloca %B*
+  store %B* %this, %B** %this1
   %0 = getelementptr %B, %B* %this, i32 0, i32 0
   call void (%A*, i32, ...) @"A.~init(iref[A],Int[32],ArgPack[Int[32],1,0])"(%A* %0, i32 4, i32 5, i32 6, i32 7, i32 8)
   ret void

--- a/Sources/Tests/Spp/Building/pointer_member_functions_test.alusus.output
+++ b/Sources/Tests/Spp/Building/pointer_member_functions_test.alusus.output
@@ -54,12 +54,16 @@ define void @"test1()"() {
 
 define void @N.__autoConstruct__(%N* %this) {
 "#block1":
-  %0 = getelementptr %N, %N* %this, i32 0, i32 0
-  store %N_vtable* @"!N.vtable", %N_vtable** %0
-  %1 = getelementptr %N, %N* %this, i32 0, i32 0
-  %2 = load %N_vtable*, %N_vtable** %1
-  %3 = getelementptr %N_vtable, %N_vtable* %2, i32 0, i32 0
-  store void (%N*)* @"N.printItImpl(iref[N])", void (%N*)** %3
+  %this1 = alloca %N*
+  store %N* %this, %N** %this1
+  %0 = load %N*, %N** %this1
+  %1 = getelementptr %N, %N* %0, i32 0, i32 0
+  store %N_vtable* @"!N.vtable", %N_vtable** %1
+  %2 = load %N*, %N** %this1
+  %3 = getelementptr %N, %N* %2, i32 0, i32 0
+  %4 = load %N_vtable*, %N_vtable** %3
+  %5 = getelementptr %N_vtable, %N_vtable* %4, i32 0, i32 0
+  store void (%N*)* @"N.printItImpl(iref[N])", void (%N*)** %5
   ret void
 }
 
@@ -76,18 +80,23 @@ define void @"N.printItImpl(iref[N])"(%N* %this) {
 
 define void @N2.__autoConstruct__(%N2* %this) {
 "#block2":
+  %this1 = alloca %N2*
+  store %N2* %this, %N2** %this1
   %0 = getelementptr %N2, %N2* %this, i32 0, i32 0
   call void @N.__autoConstruct__(%N* %0)
-  %1 = getelementptr %N2, %N2* %this, i32 0, i32 0
-  %2 = getelementptr %N, %N* %1, i32 0, i32 0
-  store %N_vtable* @"!N2.vtable", %N_vtable** %2
-  %3 = getelementptr %N2, %N2* %this, i32 0, i32 1
-  store i32 0, i32* %3
-  %4 = getelementptr %N2, %N2* %this, i32 0, i32 0
-  %5 = getelementptr %N, %N* %4, i32 0, i32 0
-  %6 = load %N_vtable*, %N_vtable** %5
-  %7 = getelementptr %N_vtable, %N_vtable* %6, i32 0, i32 0
-  store void (%N*)* bitcast (void (%N2*)* @"N2.printItImpl(ref[N2])" to void (%N*)*), void (%N*)** %7
+  %1 = load %N2*, %N2** %this1
+  %2 = getelementptr %N2, %N2* %1, i32 0, i32 0
+  %3 = getelementptr %N, %N* %2, i32 0, i32 0
+  store %N_vtable* @"!N2.vtable", %N_vtable** %3
+  %4 = load %N2*, %N2** %this1
+  %5 = getelementptr %N2, %N2* %4, i32 0, i32 1
+  store i32 0, i32* %5
+  %6 = load %N2*, %N2** %this1
+  %7 = getelementptr %N2, %N2* %6, i32 0, i32 0
+  %8 = getelementptr %N, %N* %7, i32 0, i32 0
+  %9 = load %N_vtable*, %N_vtable** %8
+  %10 = getelementptr %N_vtable, %N_vtable* %9, i32 0, i32 0
+  store void (%N*)* bitcast (void (%N2*)* @"N2.printItImpl(ref[N2])" to void (%N*)*), void (%N*)** %10
   ret void
 }
 
@@ -96,12 +105,12 @@ define void @"N2.printItImpl(ref[N2])"(%N2* %this) {
   %this1 = alloca %N2*
   store %N2* %this, %N2** %this1
   %0 = load %N2*, %N2** %this1
-  %1 = getelementptr %N2, %N2* %0, i32 0, i32 0
-  %2 = getelementptr %N, %N* %1, i32 0, i32 1
-  %3 = load %N2*, %N2** %this1
-  %4 = getelementptr %N2, %N2* %3, i32 0, i32 1
-  %5 = load i32, i32* %2
-  %6 = load i32, i32* %4
+  %1 = getelementptr %N2, %N2* %0, i32 0, i32 1
+  %2 = load %N2*, %N2** %this1
+  %3 = getelementptr %N2, %N2* %2, i32 0, i32 0
+  %4 = getelementptr %N, %N* %3, i32 0, i32 1
+  %5 = load i32, i32* %4
+  %6 = load i32, i32* %1
   %7 = add nsw i32 %5, %6
   %8 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([15 x i8], [15 x i8]* @"#anonymous1", i32 0, i32 0), i32 %7)
   ret void
@@ -149,6 +158,8 @@ define void @"test2()"() {
 
 define void @M.__autoConstruct__(%M* %this) {
 "#block1":
+  %this1 = alloca %M*
+  store %M* %this, %M** %this1
   %0 = getelementptr %M, %M* %this, i32 0, i32 1
   store void (%M*)* @"M.printItImpl(iref[M])", void (%M*)** %0
   %1 = getelementptr %M, %M* %this, i32 0, i32 2

--- a/Sources/Tests/Spp/Building/references_test.alusus.output
+++ b/Sources/Tests/Spp/Building/references_test.alusus.output
@@ -71,8 +71,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 
 %LlvmGlobalCtorDtor = type { i32, void ()*, i32* }
 
-@"!rb" = global [1 x i8]* null
 @"#anonymous0" = private constant [6 x i8] c"hello\00"
+@"!rb" = global [1 x i8]* null
 @"#anonymous1" = private constant [43 x i8] c"Before passing reference to reference. %s\0A\00"
 @"#anonymous2" = private constant [42 x i8] c"After passing reference to reference. %s\0A\00"
 @"#anonymous3" = private constant [6 x i8] c"world\00"
@@ -179,8 +179,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 
 %LlvmGlobalCtorDtor = type { i32, void ()*, i32* }
 
-@"!ri" = global i32* null
 @"!i" = global i32 0
+@"!ri" = global i32* null
 @"#anonymous0" = private constant [4 x i8] c"%d\0A\00"
 @llvm.global_ctors = appending constant [0 x %LlvmGlobalCtorDtor] zeroinitializer
 @llvm.global_dtors = appending constant [0 x %LlvmGlobalCtorDtor] zeroinitializer
@@ -213,8 +213,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 
 %LlvmGlobalCtorDtor = type { i32, void ()*, i32* }
 
-@"!rri" = global i32** null
 @"!ri" = global i32* null
+@"!rri" = global i32** null
 @"#anonymous0" = private constant [4 x i8] c"%d\0A\00"
 @llvm.global_ctors = appending constant [0 x %LlvmGlobalCtorDtor] zeroinitializer
 @llvm.global_dtors = appending constant [0 x %LlvmGlobalCtorDtor] zeroinitializer
@@ -400,7 +400,7 @@ ERROR SPPG1015 @ (229,5): Incompatible types for the given operator.
 ERROR SPPG1015 @ (230,5): Incompatible types for the given operator.
 ERROR SPPG1033 @ (232,5): Invalid operand for ~deref operator.
 ERROR SPPA1008 @ (234,5): Provided arguments do not match signature.
-ERROR SPPG1015 @ (236,5): Incompatible types for the given operator.
+ERROR SPPA1008 @ (236,5): Provided arguments do not match signature.
 Build Failed...
 --------------------- Partial LLVM IR ----------------------
 ; ModuleID = 'AlususProgram'
@@ -411,8 +411,8 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 %C = type { i32 }
 
 @"!i" = global i32 0
-@"!rri" = global i32** null
 @"!ri" = global i32* null
+@"!rri" = global i32** null
 @"#anonymous0" = private constant [4 x i8] c"abc\00"
 @llvm.global_ctors = appending constant [0 x %LlvmGlobalCtorDtor] zeroinitializer
 @llvm.global_dtors = appending constant [0 x %LlvmGlobalCtorDtor] zeroinitializer
@@ -420,12 +420,9 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 define void @"errorCases()"() {
 "#block0":
   %rf = alloca float*
-  %0 = load i32*, i32** @"!ri"
-  %1 = load i32, i32* %0
-  %2 = load float*, float** %rf
-  %3 = load float*, float** %rf
-  store float 5.000000e+00, float* %3
-  %4 = load i32, i32* @"!i"
+  %0 = load float*, float** %rf
+  store float 5.000000e+00, float* %0
+  %1 = load i32, i32* @"!i"
   %c = alloca %C
   ret void
 }

--- a/Sources/Tests/Spp/Building/temp_objs_test.alusus.output
+++ b/Sources/Tests/Spp/Building/temp_objs_test.alusus.output
@@ -193,12 +193,12 @@ define void @"C.~init(iref[C],Int[32],ArgPack[Int[32],1,0])"(%C* %this, i32 %cou
   br i1 %5, label %"#block13", label %"#block14"
 
 "#block13":                                       ; preds = %"#block12"
-  %6 = load %C*, %C** %this1
-  %7 = getelementptr %C, %C* %6, i32 0, i32 0
-  %8 = va_arg %__VaList* %__vaList, i32
-  %9 = load i32, i32* %7
-  %10 = add nsw i32 %9, %8
-  store i32 %10, i32* %7
+  %6 = va_arg %__VaList* %__vaList, i32
+  %7 = load %C*, %C** %this1
+  %8 = getelementptr %C, %C* %7, i32 0, i32 0
+  %9 = load i32, i32* %8
+  %10 = add nsw i32 %9, %6
+  store i32 %10, i32* %8
   br label %"#block12"
 
 "#block14":                                       ; preds = %"#block12"
@@ -210,6 +210,8 @@ define void @"C.~init(iref[C],Int[32],ArgPack[Int[32],1,0])"(%C* %this, i32 %cou
 
 define void @D.__autoConstruct__(%D* %this) {
 "#block1":
+  %this1 = alloca %D*
+  store %D* %this, %D** %this1
   %0 = getelementptr %D, %D* %this, i32 0, i32 0
   call void @"A.~init(iref[A])"(%A* %0)
   ret void
@@ -224,38 +226,41 @@ define void @D.__autoDestruct__(%D* %this) {
 
 define void @E.__autoConstruct__(%E* %this) {
 "#block3":
-  %0 = getelementptr %E, %E* %this, i32 0, i32 0
+  %this1 = alloca %E*
+  store %E* %this, %E** %this1
   %"#temp5" = alloca %A
   call void @"A.~init(iref[A])"(%A* %"#temp5")
-  %1 = getelementptr %A, %A* %"#temp5", i32 0, i32 0
-  %2 = load i32, i32* %1
-  store i32 %2, i32* %0
+  %0 = getelementptr %A, %A* %"#temp5", i32 0, i32 0
+  %1 = load %E*, %E** %this1
+  %2 = getelementptr %E, %E* %1, i32 0, i32 0
+  %3 = load i32, i32* %0
+  store i32 %3, i32* %2
   call void @"A.~terminate(iref[A])"(%A* %"#temp5")
-  %3 = getelementptr %E, %E* %this, i32 0, i32 1
+  %4 = getelementptr %E, %E* %this, i32 0, i32 1
   %"#temp6" = alloca %A
   call void @"A.~init(iref[A])"(%A* %"#temp6")
-  %4 = getelementptr %A, %A* %"#temp6", i32 0, i32 0
+  %5 = getelementptr %A, %A* %"#temp6", i32 0, i32 0
   %"#temp7" = alloca %A
   call void @"A.~init(iref[A])"(%A* %"#temp7")
-  %5 = getelementptr %A, %A* %"#temp7", i32 0, i32 0
-  %6 = load i32, i32* %4
+  %6 = getelementptr %A, %A* %"#temp7", i32 0, i32 0
   %7 = load i32, i32* %5
-  call void (%C*, i32, ...) @"C.~init(iref[C],Int[32],ArgPack[Int[32],1,0])"(%C* %3, i32 3, i32 %6, i32 %7, i32 5)
+  %8 = load i32, i32* %6
+  call void (%C*, i32, ...) @"C.~init(iref[C],Int[32],ArgPack[Int[32],1,0])"(%C* %4, i32 3, i32 %7, i32 %8, i32 5)
   call void @"A.~terminate(iref[A])"(%A* %"#temp6")
   call void @"A.~terminate(iref[A])"(%A* %"#temp7")
   %"#temp8" = alloca %A
   call void @"A.~init(iref[A])"(%A* %"#temp8")
-  %8 = getelementptr %A, %A* %"#temp8", i32 0, i32 0
+  %9 = getelementptr %A, %A* %"#temp8", i32 0, i32 0
   %"#temp9" = alloca %A
   call void @"A.~init(iref[A])"(%A* %"#temp9")
-  %9 = getelementptr %A, %A* %"#temp9", i32 0, i32 0
+  %10 = getelementptr %A, %A* %"#temp9", i32 0, i32 0
   %"#temp10" = alloca %A
   call void @"A.~init(iref[A])"(%A* %"#temp10")
-  %10 = getelementptr %A, %A* %"#temp10", i32 0, i32 0
-  %11 = load i32, i32* %8
+  %11 = getelementptr %A, %A* %"#temp10", i32 0, i32 0
   %12 = load i32, i32* %9
   %13 = load i32, i32* %10
-  call void (i32, ...) @"varArgFunc(Int[32],ArgPack[Int[32],0,0])"(i32 3, i32 %11, i32 %12, i32 %13)
+  %14 = load i32, i32* %11
+  call void (i32, ...) @"varArgFunc(Int[32],ArgPack[Int[32],0,0])"(i32 3, i32 %12, i32 %13, i32 %14)
   call void @"A.~terminate(iref[A])"(%A* %"#temp8")
   call void @"A.~terminate(iref[A])"(%A* %"#temp9")
   call void @"A.~terminate(iref[A])"(%A* %"#temp10")

--- a/Sources/Tests/Spp/Building/tilde_operators_test.alusus.output
+++ b/Sources/Tests/Spp/Building/tilde_operators_test.alusus.output
@@ -75,17 +75,14 @@ define void @"Main.testPtrAndCnt()=>(Void)"() {
   %10 = load float, float* %9
   %11 = fptosi float %10 to i32
   store i32 %11, i32* %i
-  %12 = load i32, i32* %i
   store i32** %pi, i32*** %ppi
-  %13 = load i32**, i32*** %ppi
-  %14 = load i32*, i32** %13
-  %15 = load i32**, i32*** %ppi
-  %16 = load i32*, i32** %15
-  %17 = load i32, i32* %16
-  store i32 %17, i32* %i
+  %12 = load i32**, i32*** %ppi
+  %13 = load i32*, i32** %12
+  %14 = load i32, i32* %13
+  store i32 %14, i32* %i
   store i32* @"!Other.i", i32** %pi
-  %18 = load i32*, i32** @"!Other.pi"
-  store i32 10, i32* %18
+  %15 = load i32*, i32** @"!Other.pi"
+  store i32 10, i32* %15
   ret void
 }
 

--- a/Sources/Tests/Spp/Building/user_types_test.alusus.output
+++ b/Sources/Tests/Spp/Building/user_types_test.alusus.output
@@ -1,8 +1,8 @@
 ERROR SPPA1003 @ (40,12): No valid match was found for the given type.
-ERROR SPPA1004 @ (77,7): No valid match was found for the given type member.
+ERROR SPPA1007 @ (77,7): Unknown symbol.
 ERROR SPPA1004 @ (80,7): No valid match was found for the given type member.
-ERROR SPPA1004 @ (81,7): No valid match was found for the given type member.
-ERROR SPPA1004 @ (84,25): No valid match was found for the given type member.
+ERROR SPPA1007 @ (81,7): Unknown symbol.
+ERROR SPPA1007 @ (84,25): Unknown symbol.
 ERROR SPPG1015 @ (101,5): Incompatible types for the given operator.
 ERROR SPPG1015 @ (103,5): Incompatible types for the given operator.
 ERROR SPPG1015 @ (104,5): Incompatible types for the given operator.
@@ -109,11 +109,11 @@ define void @"Main.start()=>(Void)"() {
   store i32 1, i32* %17
   %18 = getelementptr %Main_Nested, %Main_Nested* %n, i32 0, i32 1
   store i8 10, i8* %18
-  %19 = getelementptr %Main_Nested, %Main_Nested* %n, i32 0, i32 1
-  %20 = getelementptr %Main_Point, %Main_Point* %p, i32 0, i32 1
-  %21 = load i32, i32* %20
-  %22 = trunc i32 %21 to i8
-  store i8 %22, i8* %19
+  %19 = getelementptr %Main_Point, %Main_Point* %p, i32 0, i32 1
+  %20 = load i32, i32* %19
+  %21 = trunc i32 %20 to i8
+  %22 = getelementptr %Main_Nested, %Main_Nested* %n, i32 0, i32 1
+  store i8 %21, i8* %22
   %23 = call %Main_Point @"Main.getPoint(Int[32],Int[32],Float[32])=>(Main.Point)"(i32 1, i32 2, float 3.000000e+00)
   %24 = alloca %Main_Point
   store %Main_Point %23, %Main_Point* %24

--- a/Sources/Tests/Spp/Building/variables_test.alusus.output
+++ b/Sources/Tests/Spp/Building/variables_test.alusus.output
@@ -1,5 +1,5 @@
-ERROR SPPG1008 @ (58,5): Invalid symbol.
-ERROR SPPG1008 @ (59,5): Invalid symbol.
+ERROR SPPG1002 @ (58,5): Invalid operation.
+ERROR SPPG1002 @ (59,11): Invalid operation.
 ERROR SPPA1007 @ (60,11): Unknown symbol.
 ERROR SPPG1008 @ (61,10): Invalid symbol.
 ERROR SPPG1008 @ (62,10): Invalid symbol.

--- a/Sources/Tests/Spp/Parsing/type_ops_test.alusus
+++ b/Sources/Tests/Spp/Parsing/type_ops_test.alusus
@@ -47,10 +47,40 @@ type T {
   handler this = [v: Int] this.i = value;
   handler this = (this: Int) this.i = 5;
 
-
   handler this() return this.i;
   handler this(Int) this.i += value;
   handler this(f: float) => Float[64] {
+    return this.i + (f+0.5);
+  };
+
+
+  handler this.myprop = Int this.i = value;
+  handler this.myprop = (v:Int) this.i = v;
+
+  handler this.myprop += Int this.i += value;
+  handler this.myprop /= Int this.i /= value;
+
+  handler this.myprop = ref[this_type] this.i = value.i;
+  handler this.myprop = (v:ref[this_type]) this.i = v.i;
+
+  handler this.myprop > Int return this.i > value;
+
+  handler this.myprop - Int : Int return this.i - value;
+  handler this.myprop * Int : A {
+    def ret: A;
+    ret.i = this.i * value;
+    return ret;
+  };
+
+  handler this.myprop << Int : Int { return this.i << value };
+
+  handler this.myprop $ Int : Int return this.i $ value;
+
+  handler this.myprop:Int return this.i;
+
+  handler this.myprop() return this.i;
+  handler this.myprop(Int) this.i += value;
+  handler this.myprop(f: float) => Float[64] {
     return this.i + (f+0.5);
   };
 };

--- a/Sources/Tests/Spp/Parsing/type_ops_test.alusus.output
+++ b/Sources/Tests/Spp/Parsing/type_ops_test.alusus.output
@@ -15,307 +15,402 @@ ERROR SPPH1014 @ (48,19): Invalid handler statement.
 UserType [Main.Type]
  body: Block [Main.BlockStatements.StmtList]
   Definition [Main.Def] i: Identifier: Int [Main.Subject.Identifier]
-  Definition [Main.LeadingCmdGrp] ~init: Function 
-   type: FunctionType shared: 1, bindDisabled: 0
-    argTypes: Map
-     this: ParamPass []
-      operand: Identifier: iref
-      param: ThisTypeRef
-    retType: NULL
-   body: Block [Main.BlockStatements.StmtList]
-  Definition [Main.LeadingCmdGrp] ~init: Function 
-   type: FunctionType shared: 1, bindDisabled: 0
-    argTypes: Map
-     this: ParamPass []
-      operand: Identifier: iref
-      param: ThisTypeRef
-     a: Identifier: Int [Main.Subject.Identifier]
-     b: Identifier: Float [Main.Subject.Identifier]
-    retType: NULL
-   body: Block [Main.BlockStatements.StmtList]
+  Definition [Main.LeadingCmdGrp] ~init
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: ~init
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+      retType: NULL
+     body: Block [Main.BlockStatements.StmtList]
+  Definition [Main.LeadingCmdGrp] ~init
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: ~init
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       a: Identifier: Int [Main.Subject.Identifier]
+       b: Identifier: Float [Main.Subject.Identifier]
+      retType: NULL
+     body: Block [Main.BlockStatements.StmtList]
   Block [Main.BlockStatements.StmtList]
   Bracket [] [Main.BlockSubject.Sbj]
    operand: NULL
   Block [Main.BlockStatements.StmtList]
-  Definition [Main.LeadingCmdGrp] ~terminate: Function 
-   type: FunctionType shared: 1, bindDisabled: 0
-    argTypes: Map
-     this: ParamPass []
-      operand: Identifier: iref
-      param: ThisTypeRef
-    retType: NULL
-   body: Block [Main.BlockStatements.StmtList]
-  Definition [Main.LeadingCmdGrp] ~terminate: Function 
-   type: FunctionType shared: 1, bindDisabled: 0
-    argTypes: Map
-     this: ParamPass []
-      operand: Identifier: iref
-      param: ThisTypeRef
-    retType: NULL
-   body: Block [Main.BlockStatements.StmtList]
+  Definition [Main.LeadingCmdGrp] ~terminate
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: ~terminate
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+      retType: NULL
+     body: Block [Main.BlockStatements.StmtList]
+  Definition [Main.LeadingCmdGrp] ~terminate
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: ~terminate
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+      retType: NULL
+     body: Block [Main.BlockStatements.StmtList]
   Block [Main.BlockStatements.StmtList]
   Bracket [] [Main.BlockSubject.Sbj]
    operand: NULL
   Block [Main.BlockStatements.StmtList]
-  Definition [Main.LeadingCmdGrp] =: Function 
-   type: FunctionType shared: 1, bindDisabled: 0
-    argTypes: Map
-     this: ParamPass []
-      operand: Identifier: iref
-      param: ThisTypeRef
-     value: Identifier: Int [Main.Subject.Identifier]
-    retType: ParamPass []
-     operand: Identifier: iref
-     param: ThisTypeRef
-   body: Scope
-    AssignmentOperator = [Main.BlockExpression.AssignmentExp]
-     first: LinkOperator . [Main.BlockExpression.LinkExp]
-      first: Identifier: this [Main.Keywords]
-      second: Identifier: i [Main.BlockSubject.Identifier]
-     second: Identifier: value [Main.Keywords]
-    ReturnStatement
-     operand: Identifier: this
-  Definition [Main.LeadingCmdGrp] =: Function 
-   type: FunctionType shared: 1, bindDisabled: 0
-    argTypes: Map
-     this: ParamPass []
-      operand: Identifier: iref
-      param: ThisTypeRef
-     v: Identifier: Int [Main.Subject.Identifier]
-    retType: ParamPass []
-     operand: Identifier: iref
-     param: ThisTypeRef
-   body: Scope
-    AssignmentOperator = [Main.BlockExpression.AssignmentExp]
-     first: LinkOperator . [Main.BlockExpression.LinkExp]
-      first: Identifier: this [Main.Keywords]
-      second: Identifier: i [Main.BlockSubject.Identifier]
-     second: Identifier: v [Main.BlockSubject.Identifier]
-    ReturnStatement
-     operand: Identifier: this
-  Definition [Main.LeadingCmdGrp] +=: Function 
-   type: FunctionType shared: 1, bindDisabled: 0
-    argTypes: Map
-     this: ParamPass []
-      operand: Identifier: iref
-      param: ThisTypeRef
-     value: Identifier: Int [Main.Subject.Identifier]
-    retType: ParamPass []
-     operand: Identifier: iref
-     param: ThisTypeRef
-   body: Scope
-    AssignmentOperator += [Main.BlockExpression.AssignmentExp]
-     first: LinkOperator . [Main.BlockExpression.LinkExp]
-      first: Identifier: this [Main.Keywords]
-      second: Identifier: i [Main.BlockSubject.Identifier]
-     second: Identifier: value [Main.Keywords]
-    ReturnStatement
-     operand: Identifier: this
-  Definition [Main.LeadingCmdGrp] /=: Function 
-   type: FunctionType shared: 1, bindDisabled: 0
-    argTypes: Map
-     this: ParamPass []
-      operand: Identifier: iref
-      param: ThisTypeRef
-     value: Identifier: Int [Main.Subject.Identifier]
-    retType: ParamPass []
-     operand: Identifier: iref
-     param: ThisTypeRef
-   body: Scope
-    AssignmentOperator /= [Main.BlockExpression.AssignmentExp]
-     first: LinkOperator . [Main.BlockExpression.LinkExp]
-      first: Identifier: this [Main.Keywords]
-      second: Identifier: i [Main.BlockSubject.Identifier]
-     second: Identifier: value [Main.Keywords]
-    ReturnStatement
-     operand: Identifier: this
-  Definition [Main.LeadingCmdGrp] =: Function 
-   type: FunctionType shared: 1, bindDisabled: 0
-    argTypes: Map
-     this: ParamPass []
-      operand: Identifier: iref
-      param: ThisTypeRef
-     value: ParamPass [] [Main.Expression.ParamPassExp]
-      operand: Identifier: ref [Main.Subject.Identifier]
-      param: ThisTypeRef [Main.ThisTypeRef]
-    retType: ParamPass []
-     operand: Identifier: iref
-     param: ThisTypeRef
-   body: Scope
-    AssignmentOperator = [Main.BlockExpression.AssignmentExp]
-     first: LinkOperator . [Main.BlockExpression.LinkExp]
-      first: Identifier: this [Main.Keywords]
-      second: Identifier: i [Main.BlockSubject.Identifier]
-     second: LinkOperator . [Main.BlockExpression.LinkExp]
-      first: Identifier: value [Main.Keywords]
-      second: Identifier: i [Main.BlockSubject.Identifier]
-    ReturnStatement
-     operand: Identifier: this
-  Definition [Main.LeadingCmdGrp] =: Function 
-   type: FunctionType shared: 1, bindDisabled: 0
-    argTypes: Map
-     this: ParamPass []
-      operand: Identifier: iref
-      param: ThisTypeRef
-     v: ParamPass [] [Main.Expression.ParamPassExp]
-      operand: Identifier: ref [Main.Subject.Identifier]
-      param: ThisTypeRef [Main.ThisTypeRef]
-    retType: ParamPass []
-     operand: Identifier: iref
-     param: ThisTypeRef
-   body: Scope
-    AssignmentOperator = [Main.BlockExpression.AssignmentExp]
-     first: LinkOperator . [Main.BlockExpression.LinkExp]
-      first: Identifier: this [Main.Keywords]
-      second: Identifier: i [Main.BlockSubject.Identifier]
-     second: LinkOperator . [Main.BlockExpression.LinkExp]
-      first: Identifier: v [Main.BlockSubject.Identifier]
-      second: Identifier: i [Main.BlockSubject.Identifier]
-    ReturnStatement
-     operand: Identifier: this
-  Definition [Main.LeadingCmdGrp] >: Function 
-   type: FunctionType shared: 1, bindDisabled: 0
-    argTypes: Map
-     this: ParamPass []
-      operand: Identifier: iref
-      param: ThisTypeRef
-     value: Identifier: Int [Main.Subject.Identifier]
-    retType: ParamPass []
-     operand: Identifier: Word
-     param: IntegerLiteral: 1
-   body: Scope
-    ReturnStatement [Main.Return]
-     operand: ComparisonOperator > [Main.Expression.ComparisonExp]
-      first: LinkOperator . [Main.Expression.LinkExp]
-       first: Identifier: this [Main.Keywords]
-       second: Identifier: i [Main.Subject.Identifier]
-      second: Identifier: value [Main.Keywords]
-  Definition [Main.LeadingCmdGrp] -: Function 
-   type: FunctionType shared: 1, bindDisabled: 0
-    argTypes: Map
-     this: ParamPass []
-      operand: Identifier: iref
-      param: ThisTypeRef
-     value: Identifier: Int [Main.Subject.Identifier]
-    retType: Identifier: Int [Main.Subject.Identifier]
-   body: Scope
-    ReturnStatement [Main.Return]
-     operand: AdditionOperator - [Main.Expression.AddExp]
-      first: LinkOperator . [Main.Expression.LinkExp]
-       first: Identifier: this [Main.Keywords]
-       second: Identifier: i [Main.Subject.Identifier]
-      second: Identifier: value [Main.Keywords]
-  Definition [Main.LeadingCmdGrp] *: Function 
-   type: FunctionType shared: 1, bindDisabled: 0
-    argTypes: Map
-     this: ParamPass []
-      operand: Identifier: iref
-      param: ThisTypeRef
-     value: Identifier: Int [Main.Subject.Identifier]
-    retType: Identifier: A [Main.Subject.Identifier]
-   body: Block [Main.BlockStatements.StmtList]
-    Definition [Main.Def] ret: Identifier: A [Main.Subject.Identifier]
-    AssignmentOperator = [Main.BlockExpression.AssignmentExp]
-     first: LinkOperator . [Main.BlockExpression.LinkExp]
-      first: Identifier: ret [Main.BlockSubject.Identifier]
-      second: Identifier: i [Main.BlockSubject.Identifier]
-     second: MultiplicationOperator * [Main.BlockExpression.MulExp]
-      first: LinkOperator . [Main.BlockExpression.LinkExp]
-       first: Identifier: this [Main.Keywords]
-       second: Identifier: i [Main.BlockSubject.Identifier]
-      second: Identifier: value [Main.Keywords]
-    ReturnStatement [Main.Return]
-     operand: Identifier: ret [Main.Subject.Identifier]
-  Definition [Main.LeadingCmdGrp] <<: Function 
-   type: FunctionType shared: 1, bindDisabled: 0
-    argTypes: Map
-     this: ParamPass []
-      operand: Identifier: iref
-      param: ThisTypeRef
-     value: Identifier: Int [Main.Subject.Identifier]
-    retType: Identifier: Int [Main.Subject.Identifier]
-   body: Block [Main.BlockStatements.StmtList]
-    ReturnStatement [Main.Return]
-     operand: BitwiseOperator << [Main.Expression.BitwiseExp]
-      first: LinkOperator . [Main.Expression.LinkExp]
-       first: Identifier: this [Main.Keywords]
-       second: Identifier: i [Main.Subject.Identifier]
-      second: Identifier: value [Main.Keywords]
-  Definition [Main.LeadingCmdGrp] $: Function 
-   type: FunctionType shared: 1, bindDisabled: 0
-    argTypes: Map
-     this: ParamPass []
-      operand: Identifier: iref
-      param: ThisTypeRef
-     value: Identifier: Int [Main.Subject.Identifier]
-    retType: Identifier: Int [Main.Subject.Identifier]
-   body: Scope
-    ReturnStatement [Main.Return]
-     operand: BitwiseOperator $ [Main.Expression.BitwiseExp]
-      first: LinkOperator . [Main.Expression.LinkExp]
-       first: Identifier: this [Main.Keywords]
-       second: Identifier: i [Main.Subject.Identifier]
-      second: Identifier: value [Main.Keywords]
-  Definition [Main.LeadingCmdGrp] ~cast: Function 
-   type: FunctionType shared: 1, bindDisabled: 0
-    argTypes: Map
-     this: ParamPass []
-      operand: Identifier: iref
-      param: ThisTypeRef
-    retType: Identifier: Int [Main.Subject.Identifier]
-   body: Scope
-    ReturnStatement [Main.Return]
-     operand: LinkOperator . [Main.Expression.LinkExp]
-      first: Identifier: this [Main.Keywords]
-      second: Identifier: i [Main.Subject.Identifier]
+  Definition [Main.LeadingCmdGrp] =
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: =
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       value: Identifier: Int [Main.Subject.Identifier]
+      retType: ParamPass []
+       operand: Identifier: iref
+       param: ThisTypeRef
+     body: Scope
+      AssignmentOperator = [Main.BlockExpression.AssignmentExp]
+       first: LinkOperator . [Main.BlockExpression.LinkExp]
+        first: Identifier: this [Main.Keywords]
+        second: Identifier: i [Main.BlockSubject.Identifier]
+       second: Identifier: value [Main.Keywords]
+      ReturnStatement
+       operand: Identifier: this
+  Definition [Main.LeadingCmdGrp] =
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: =
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       v: Identifier: Int [Main.Subject.Identifier]
+      retType: ParamPass []
+       operand: Identifier: iref
+       param: ThisTypeRef
+     body: Scope
+      AssignmentOperator = [Main.BlockExpression.AssignmentExp]
+       first: LinkOperator . [Main.BlockExpression.LinkExp]
+        first: Identifier: this [Main.Keywords]
+        second: Identifier: i [Main.BlockSubject.Identifier]
+       second: Identifier: v [Main.BlockSubject.Identifier]
+      ReturnStatement
+       operand: Identifier: this
+  Definition [Main.LeadingCmdGrp] +=
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: +=
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       value: Identifier: Int [Main.Subject.Identifier]
+      retType: ParamPass []
+       operand: Identifier: iref
+       param: ThisTypeRef
+     body: Scope
+      AssignmentOperator += [Main.BlockExpression.AssignmentExp]
+       first: LinkOperator . [Main.BlockExpression.LinkExp]
+        first: Identifier: this [Main.Keywords]
+        second: Identifier: i [Main.BlockSubject.Identifier]
+       second: Identifier: value [Main.Keywords]
+      ReturnStatement
+       operand: Identifier: this
+  Definition [Main.LeadingCmdGrp] /=
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: /=
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       value: Identifier: Int [Main.Subject.Identifier]
+      retType: ParamPass []
+       operand: Identifier: iref
+       param: ThisTypeRef
+     body: Scope
+      AssignmentOperator /= [Main.BlockExpression.AssignmentExp]
+       first: LinkOperator . [Main.BlockExpression.LinkExp]
+        first: Identifier: this [Main.Keywords]
+        second: Identifier: i [Main.BlockSubject.Identifier]
+       second: Identifier: value [Main.Keywords]
+      ReturnStatement
+       operand: Identifier: this
+  Definition [Main.LeadingCmdGrp] =
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: =
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       value: ParamPass [] [Main.Expression.ParamPassExp]
+        operand: Identifier: ref [Main.Subject.Identifier]
+        param: ThisTypeRef [Main.ThisTypeRef]
+      retType: ParamPass []
+       operand: Identifier: iref
+       param: ThisTypeRef
+     body: Scope
+      AssignmentOperator = [Main.BlockExpression.AssignmentExp]
+       first: LinkOperator . [Main.BlockExpression.LinkExp]
+        first: Identifier: this [Main.Keywords]
+        second: Identifier: i [Main.BlockSubject.Identifier]
+       second: LinkOperator . [Main.BlockExpression.LinkExp]
+        first: Identifier: value [Main.Keywords]
+        second: Identifier: i [Main.BlockSubject.Identifier]
+      ReturnStatement
+       operand: Identifier: this
+  Definition [Main.LeadingCmdGrp] =
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: =
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       v: ParamPass [] [Main.Expression.ParamPassExp]
+        operand: Identifier: ref [Main.Subject.Identifier]
+        param: ThisTypeRef [Main.ThisTypeRef]
+      retType: ParamPass []
+       operand: Identifier: iref
+       param: ThisTypeRef
+     body: Scope
+      AssignmentOperator = [Main.BlockExpression.AssignmentExp]
+       first: LinkOperator . [Main.BlockExpression.LinkExp]
+        first: Identifier: this [Main.Keywords]
+        second: Identifier: i [Main.BlockSubject.Identifier]
+       second: LinkOperator . [Main.BlockExpression.LinkExp]
+        first: Identifier: v [Main.BlockSubject.Identifier]
+        second: Identifier: i [Main.BlockSubject.Identifier]
+      ReturnStatement
+       operand: Identifier: this
+  Definition [Main.LeadingCmdGrp] >
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: >
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       value: Identifier: Int [Main.Subject.Identifier]
+      retType: ParamPass []
+       operand: Identifier: Word
+       param: IntegerLiteral: 1
+     body: Scope
+      ReturnStatement [Main.Return]
+       operand: ComparisonOperator > [Main.Expression.ComparisonExp]
+        first: LinkOperator . [Main.Expression.LinkExp]
+         first: Identifier: this [Main.Keywords]
+         second: Identifier: i [Main.Subject.Identifier]
+        second: Identifier: value [Main.Keywords]
+  Definition [Main.LeadingCmdGrp] -
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: -
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       value: Identifier: Int [Main.Subject.Identifier]
+      retType: Identifier: Int [Main.Subject.Identifier]
+     body: Scope
+      ReturnStatement [Main.Return]
+       operand: AdditionOperator - [Main.Expression.AddExp]
+        first: LinkOperator . [Main.Expression.LinkExp]
+         first: Identifier: this [Main.Keywords]
+         second: Identifier: i [Main.Subject.Identifier]
+        second: Identifier: value [Main.Keywords]
+  Definition [Main.LeadingCmdGrp] *
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: *
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       value: Identifier: Int [Main.Subject.Identifier]
+      retType: Identifier: A [Main.Subject.Identifier]
+     body: Block [Main.BlockStatements.StmtList]
+      Definition [Main.Def] ret: Identifier: A [Main.Subject.Identifier]
+      AssignmentOperator = [Main.BlockExpression.AssignmentExp]
+       first: LinkOperator . [Main.BlockExpression.LinkExp]
+        first: Identifier: ret [Main.BlockSubject.Identifier]
+        second: Identifier: i [Main.BlockSubject.Identifier]
+       second: MultiplicationOperator * [Main.BlockExpression.MulExp]
+        first: LinkOperator . [Main.BlockExpression.LinkExp]
+         first: Identifier: this [Main.Keywords]
+         second: Identifier: i [Main.BlockSubject.Identifier]
+        second: Identifier: value [Main.Keywords]
+      ReturnStatement [Main.Return]
+       operand: Identifier: ret [Main.Subject.Identifier]
+  Definition [Main.LeadingCmdGrp] <<
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: <<
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       value: Identifier: Int [Main.Subject.Identifier]
+      retType: Identifier: Int [Main.Subject.Identifier]
+     body: Block [Main.BlockStatements.StmtList]
+      ReturnStatement [Main.Return]
+       operand: BitwiseOperator << [Main.Expression.BitwiseExp]
+        first: LinkOperator . [Main.Expression.LinkExp]
+         first: Identifier: this [Main.Keywords]
+         second: Identifier: i [Main.Subject.Identifier]
+        second: Identifier: value [Main.Keywords]
+  Definition [Main.LeadingCmdGrp] $
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: $
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       value: Identifier: Int [Main.Subject.Identifier]
+      retType: Identifier: Int [Main.Subject.Identifier]
+     body: Scope
+      ReturnStatement [Main.Return]
+       operand: BitwiseOperator $ [Main.Expression.BitwiseExp]
+        first: LinkOperator . [Main.Expression.LinkExp]
+         first: Identifier: this [Main.Keywords]
+         second: Identifier: i [Main.Subject.Identifier]
+        second: Identifier: value [Main.Keywords]
+  Definition [Main.LeadingCmdGrp] ~cast
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: ~cast
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+      retType: Identifier: Int [Main.Subject.Identifier]
+     body: Scope
+      ReturnStatement [Main.Return]
+       operand: LinkOperator . [Main.Expression.LinkExp]
+        first: Identifier: this [Main.Keywords]
+        second: Identifier: i [Main.Subject.Identifier]
   ReturnStatement [Main.Return]
    operand: LinkOperator . [Main.Expression.LinkExp]
     first: Identifier: this [Main.Keywords]
     second: Identifier: i [Main.Subject.Identifier]
-  Definition [Main.LeadingCmdGrp] (): Function 
-   type: FunctionType shared: 1, bindDisabled: 0
-    argTypes: Map
-     this: ParamPass []
-      operand: Identifier: iref
-      param: ThisTypeRef
-    retType: NULL
-   body: Scope
-    ReturnStatement [Main.Return]
-     operand: LinkOperator . [Main.Expression.LinkExp]
-      first: Identifier: this [Main.Keywords]
-      second: Identifier: i [Main.Subject.Identifier]
-  Definition [Main.LeadingCmdGrp] (): Function 
-   type: FunctionType shared: 1, bindDisabled: 0
-    argTypes: Map
-     this: ParamPass []
-      operand: Identifier: iref
-      param: ThisTypeRef
-     value: Identifier: Int [Main.Subject.Identifier]
-    retType: NULL
-   body: Scope
-    AssignmentOperator += [Main.BlockExpression.AssignmentExp]
-     first: LinkOperator . [Main.BlockExpression.LinkExp]
-      first: Identifier: this [Main.Keywords]
-      second: Identifier: i [Main.BlockSubject.Identifier]
-     second: Identifier: value [Main.Keywords]
-  Definition [Main.LeadingCmdGrp] (): Function 
-   type: FunctionType shared: 1, bindDisabled: 0
-    argTypes: Map
-     this: ParamPass []
-      operand: Identifier: iref
-      param: ThisTypeRef
-     f: Identifier: float [Main.Subject.Identifier]
-    retType: ParamPass [] [Main.Expression.ParamPassExp]
-     operand: Identifier: Float [Main.Subject.Identifier]
-     param: IntegerLiteral: 64 [Main.Subject.Literal]
-   body: Block [Main.BlockStatements.StmtList]
-    ReturnStatement [Main.Return]
-     operand: AdditionOperator + [Main.Expression.AddExp]
-      first: LinkOperator . [Main.Expression.LinkExp]
-       first: Identifier: this [Main.Keywords]
-       second: Identifier: i [Main.Subject.Identifier]
-      second: Bracket () [Main.Subject.Sbj]
+  Definition [Main.LeadingCmdGrp] ()
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: ()
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+      retType: NULL
+     body: Scope
+      ReturnStatement [Main.Return]
+       operand: LinkOperator . [Main.Expression.LinkExp]
+        first: Identifier: this [Main.Keywords]
+        second: Identifier: i [Main.Subject.Identifier]
+  Definition [Main.LeadingCmdGrp] ()
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: ()
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       value: Identifier: Int [Main.Subject.Identifier]
+      retType: NULL
+     body: Scope
+      AssignmentOperator += [Main.BlockExpression.AssignmentExp]
+       first: LinkOperator . [Main.BlockExpression.LinkExp]
+        first: Identifier: this [Main.Keywords]
+        second: Identifier: i [Main.BlockSubject.Identifier]
+       second: Identifier: value [Main.Keywords]
+  Definition [Main.LeadingCmdGrp] ()
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: ()
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       f: Identifier: float [Main.Subject.Identifier]
+      retType: ParamPass [] [Main.Expression.ParamPassExp]
+       operand: Identifier: Float [Main.Subject.Identifier]
+       param: IntegerLiteral: 64 [Main.Subject.Literal]
+     body: Block [Main.BlockStatements.StmtList]
+      ReturnStatement [Main.Return]
        operand: AdditionOperator + [Main.Expression.AddExp]
-        first: Identifier: f [Main.Subject.Identifier]
-        second: FloatLiteral: 0.5 [Main.Subject.Literal]
+        first: LinkOperator . [Main.Expression.LinkExp]
+         first: Identifier: this [Main.Keywords]
+         second: Identifier: i [Main.Subject.Identifier]
+        second: Bracket () [Main.Subject.Sbj]
+         operand: AdditionOperator + [Main.Expression.AddExp]
+          first: Identifier: f [Main.Subject.Identifier]
+          second: FloatLiteral: 0.5 [Main.Subject.Literal]
 ------------------------------------------------------

--- a/Sources/Tests/Spp/Parsing/type_ops_test.alusus.output
+++ b/Sources/Tests/Spp/Parsing/type_ops_test.alusus.output
@@ -413,4 +413,316 @@ UserType [Main.Type]
          operand: AdditionOperator + [Main.Expression.AddExp]
           first: Identifier: f [Main.Subject.Identifier]
           second: FloatLiteral: 0.5 [Main.Subject.Literal]
+  Definition [Main.LeadingCmdGrp] myprop
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: =
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       value: Identifier: Int [Main.Subject.Identifier]
+      retType: Identifier: Int [Main.Subject.Identifier]
+     body: Scope
+      AssignmentOperator = [Main.BlockExpression.AssignmentExp]
+       first: LinkOperator . [Main.BlockExpression.LinkExp]
+        first: Identifier: this [Main.Keywords]
+        second: Identifier: i [Main.BlockSubject.Identifier]
+       second: Identifier: value [Main.Keywords]
+  Definition [Main.LeadingCmdGrp] myprop
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: =
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       v: Identifier: Int [Main.Subject.Identifier]
+      retType: Identifier: Int [Main.Subject.Identifier]
+     body: Scope
+      AssignmentOperator = [Main.BlockExpression.AssignmentExp]
+       first: LinkOperator . [Main.BlockExpression.LinkExp]
+        first: Identifier: this [Main.Keywords]
+        second: Identifier: i [Main.BlockSubject.Identifier]
+       second: Identifier: v [Main.BlockSubject.Identifier]
+  Definition [Main.LeadingCmdGrp] myprop
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: +=
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       value: Identifier: Int [Main.Subject.Identifier]
+      retType: Identifier: Int [Main.Subject.Identifier]
+     body: Scope
+      AssignmentOperator += [Main.BlockExpression.AssignmentExp]
+       first: LinkOperator . [Main.BlockExpression.LinkExp]
+        first: Identifier: this [Main.Keywords]
+        second: Identifier: i [Main.BlockSubject.Identifier]
+       second: Identifier: value [Main.Keywords]
+  Definition [Main.LeadingCmdGrp] myprop
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: /=
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       value: Identifier: Int [Main.Subject.Identifier]
+      retType: Identifier: Int [Main.Subject.Identifier]
+     body: Scope
+      AssignmentOperator /= [Main.BlockExpression.AssignmentExp]
+       first: LinkOperator . [Main.BlockExpression.LinkExp]
+        first: Identifier: this [Main.Keywords]
+        second: Identifier: i [Main.BlockSubject.Identifier]
+       second: Identifier: value [Main.Keywords]
+  Definition [Main.LeadingCmdGrp] myprop
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: =
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       value: ParamPass [] [Main.Expression.ParamPassExp]
+        operand: Identifier: ref [Main.Subject.Identifier]
+        param: ThisTypeRef [Main.ThisTypeRef]
+      retType: ParamPass [] [Main.Expression.ParamPassExp]
+       operand: Identifier: ref [Main.Subject.Identifier]
+       param: ThisTypeRef [Main.ThisTypeRef]
+     body: Scope
+      AssignmentOperator = [Main.BlockExpression.AssignmentExp]
+       first: LinkOperator . [Main.BlockExpression.LinkExp]
+        first: Identifier: this [Main.Keywords]
+        second: Identifier: i [Main.BlockSubject.Identifier]
+       second: LinkOperator . [Main.BlockExpression.LinkExp]
+        first: Identifier: value [Main.Keywords]
+        second: Identifier: i [Main.BlockSubject.Identifier]
+  Definition [Main.LeadingCmdGrp] myprop
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: =
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       v: ParamPass [] [Main.Expression.ParamPassExp]
+        operand: Identifier: ref [Main.Subject.Identifier]
+        param: ThisTypeRef [Main.ThisTypeRef]
+      retType: ParamPass [] [Main.Expression.ParamPassExp]
+       operand: Identifier: ref [Main.Subject.Identifier]
+       param: ThisTypeRef [Main.ThisTypeRef]
+     body: Scope
+      AssignmentOperator = [Main.BlockExpression.AssignmentExp]
+       first: LinkOperator . [Main.BlockExpression.LinkExp]
+        first: Identifier: this [Main.Keywords]
+        second: Identifier: i [Main.BlockSubject.Identifier]
+       second: LinkOperator . [Main.BlockExpression.LinkExp]
+        first: Identifier: v [Main.BlockSubject.Identifier]
+        second: Identifier: i [Main.BlockSubject.Identifier]
+  Definition [Main.LeadingCmdGrp] myprop
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: >
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       value: Identifier: Int [Main.Subject.Identifier]
+      retType: ParamPass []
+       operand: Identifier: Word
+       param: IntegerLiteral: 1
+     body: Scope
+      ReturnStatement [Main.Return]
+       operand: ComparisonOperator > [Main.Expression.ComparisonExp]
+        first: LinkOperator . [Main.Expression.LinkExp]
+         first: Identifier: this [Main.Keywords]
+         second: Identifier: i [Main.Subject.Identifier]
+        second: Identifier: value [Main.Keywords]
+  Definition [Main.LeadingCmdGrp] myprop
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: -
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       value: Identifier: Int [Main.Subject.Identifier]
+      retType: Identifier: Int [Main.Subject.Identifier]
+     body: Scope
+      ReturnStatement [Main.Return]
+       operand: AdditionOperator - [Main.Expression.AddExp]
+        first: LinkOperator . [Main.Expression.LinkExp]
+         first: Identifier: this [Main.Keywords]
+         second: Identifier: i [Main.Subject.Identifier]
+        second: Identifier: value [Main.Keywords]
+  Definition [Main.LeadingCmdGrp] myprop
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: *
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       value: Identifier: Int [Main.Subject.Identifier]
+      retType: Identifier: A [Main.Subject.Identifier]
+     body: Block [Main.BlockStatements.StmtList]
+      Definition [Main.Def] ret: Identifier: A [Main.Subject.Identifier]
+      AssignmentOperator = [Main.BlockExpression.AssignmentExp]
+       first: LinkOperator . [Main.BlockExpression.LinkExp]
+        first: Identifier: ret [Main.BlockSubject.Identifier]
+        second: Identifier: i [Main.BlockSubject.Identifier]
+       second: MultiplicationOperator * [Main.BlockExpression.MulExp]
+        first: LinkOperator . [Main.BlockExpression.LinkExp]
+         first: Identifier: this [Main.Keywords]
+         second: Identifier: i [Main.BlockSubject.Identifier]
+        second: Identifier: value [Main.Keywords]
+      ReturnStatement [Main.Return]
+       operand: Identifier: ret [Main.Subject.Identifier]
+  Definition [Main.LeadingCmdGrp] myprop
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: <<
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       value: Identifier: Int [Main.Subject.Identifier]
+      retType: Identifier: Int [Main.Subject.Identifier]
+     body: Block [Main.BlockStatements.StmtList]
+      ReturnStatement [Main.Return]
+       operand: BitwiseOperator << [Main.Expression.BitwiseExp]
+        first: LinkOperator . [Main.Expression.LinkExp]
+         first: Identifier: this [Main.Keywords]
+         second: Identifier: i [Main.Subject.Identifier]
+        second: Identifier: value [Main.Keywords]
+  Definition [Main.LeadingCmdGrp] myprop
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: $
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       value: Identifier: Int [Main.Subject.Identifier]
+      retType: Identifier: Int [Main.Subject.Identifier]
+     body: Scope
+      ReturnStatement [Main.Return]
+       operand: BitwiseOperator $ [Main.Expression.BitwiseExp]
+        first: LinkOperator . [Main.Expression.LinkExp]
+         first: Identifier: this [Main.Keywords]
+         second: Identifier: i [Main.Subject.Identifier]
+        second: Identifier: value [Main.Keywords]
+  Definition [Main.LeadingCmdGrp] myprop
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: 
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+      retType: Identifier: Int [Main.Subject.Identifier]
+     body: Scope
+      ReturnStatement [Main.Return]
+       operand: LinkOperator . [Main.Expression.LinkExp]
+        first: Identifier: this [Main.Keywords]
+        second: Identifier: i [Main.Subject.Identifier]
+  Definition [Main.LeadingCmdGrp] myprop
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: ()
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+      retType: NULL
+     body: Scope
+      ReturnStatement [Main.Return]
+       operand: LinkOperator . [Main.Expression.LinkExp]
+        first: Identifier: this [Main.Keywords]
+        second: Identifier: i [Main.Subject.Identifier]
+  Definition [Main.LeadingCmdGrp] myprop
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: ()
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       value: Identifier: Int [Main.Subject.Identifier]
+      retType: NULL
+     body: Scope
+      AssignmentOperator += [Main.BlockExpression.AssignmentExp]
+       first: LinkOperator . [Main.BlockExpression.LinkExp]
+        first: Identifier: this [Main.Keywords]
+        second: Identifier: i [Main.BlockSubject.Identifier]
+       second: Identifier: value [Main.Keywords]
+  Definition [Main.LeadingCmdGrp] myprop
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: ()
+   target: Function 
+     type: FunctionType shared: 1, bindDisabled: 0
+      argTypes: Map
+       this: ParamPass []
+        operand: Identifier: iref
+        param: ThisTypeRef
+       f: Identifier: float [Main.Subject.Identifier]
+      retType: ParamPass [] [Main.Expression.ParamPassExp]
+       operand: Identifier: Float [Main.Subject.Identifier]
+       param: IntegerLiteral: 64 [Main.Subject.Literal]
+     body: Block [Main.BlockStatements.StmtList]
+      ReturnStatement [Main.Return]
+       operand: AdditionOperator + [Main.Expression.AddExp]
+        first: LinkOperator . [Main.Expression.LinkExp]
+         first: Identifier: this [Main.Keywords]
+         second: Identifier: i [Main.Subject.Identifier]
+        second: Bracket () [Main.Subject.Sbj]
+         operand: AdditionOperator + [Main.Expression.AddExp]
+          first: Identifier: f [Main.Subject.Identifier]
+          second: FloatLiteral: 0.5 [Main.Subject.Literal]
 ------------------------------------------------------

--- a/Sources/Tests/Spp/Running/aliases_test.alusus
+++ b/Sources/Tests/Spp/Running/aliases_test.alusus
@@ -1,0 +1,24 @@
+import "Srl/Console.alusus";
+import "Srl/Array";
+use Srl;
+
+def IntArray: alias Array[Int];
+
+func printInts (a: ref[IntArray]) {
+    Console.print("Root.printInts\n");
+}
+
+printInts(IntArray({ 4, 5, 6 }));
+
+module Test {
+    func printInts (a: ref[IntArray]) {
+        Console.print("Root.Test.printInts\n");
+    }
+
+    def printIntsAlias: alias printInts;
+
+    function test {
+        printIntsAlias(IntArray({ 4, 5, 6 }));
+    }
+}
+Test.test();

--- a/Sources/Tests/Spp/Running/aliases_test.alusus.output
+++ b/Sources/Tests/Spp/Running/aliases_test.alusus.output
@@ -1,0 +1,2 @@
+Root.printInts
+Root.Test.printInts

--- a/Sources/Tests/Spp/Running/circular_referencing_test.alusus.output
+++ b/Sources/Tests/Spp/Running/circular_referencing_test.alusus.output
@@ -1,2 +1,2 @@
 Did not crash!
-ERROR SPPG1015 @ (19,1): Incompatible types for the given operator.
+ERROR SPPG1015 @ (19,5): Incompatible types for the given operator.

--- a/Sources/Tests/Spp/Running/member_functions_test.alusus
+++ b/Sources/Tests/Spp/Running/member_functions_test.alusus
@@ -7,7 +7,7 @@ type A
   def i: Int;
 
   func print {
-    print("this.i = %d\n", this.i);
+    Root.print("this.i = %d\n", this.i);
   };
 
   func setI (i: Int) {

--- a/Sources/Tests/Spp/Running/references_test.alusus
+++ b/Sources/Tests/Spp/Running/references_test.alusus
@@ -103,8 +103,6 @@ function printNumPtr (pn: ptr[Int])
 {
     print("%d\n", pn~cnt);
 };
-def i: Int;
-def ri: ref[Int];
 ri~ptr = i~ptr;
 i = 5;
 print("Passing ref[int] as ptr[int]. ");

--- a/Sources/Tests/Spp/Running/root_scope_test.alusus.output
+++ b/Sources/Tests/Spp/Running/root_scope_test.alusus.output
@@ -6,8 +6,9 @@
 24
 factorial of 6 using function pointer: 720
 ERROR SPPA1003 @ (25,10): No valid match was found for the given type.
-ERROR SPPG1024 @ (26,3): Trying to access a local variable before it's initialized.
-ERROR SPPG1024 @ (27,10): Trying to access a local variable before it's initialized.
+ERROR SPPA1007 @ (26,7): Unknown symbol.
+ERROR SPPA1003 @ (25,10): No valid match was found for the given type.
+ERROR SPPA1003 @ (27,10): No valid match was found for the given type.
 Build Failed...
 --------------------- Partial LLVM IR ----------------------
 ; ModuleID = 'AlususProgram'

--- a/Sources/Tests/Spp/Running/type_ops_test.alusus
+++ b/Sources/Tests/Spp/Running/type_ops_test.alusus
@@ -2,37 +2,74 @@ import "Srl/Console.alusus";
 use Srl.Console;
 
 type T {
-  def i: Int;
+    def i: Int(0);
+    def j: Int(0);
 
-  handler this = Int this.i = value;
+    handler this~init() {}
+    handler this~init(t: ref[T]) {
+        this.i = t.i;
+        this.j = t.j;
+    }
 
-  handler this += (v:Int) this.i += v;
-  handler this /= (v:Int) this.i /= v;
+    handler this = Int this.i = value;
 
-  handler this = ref[this_type] this.i = value.i;
+    handler this += (v:Int) this.i += v;
+    handler this /= (v:Int) this.i /= v;
 
-  handler this < Int return this.i < value;
+    handler this = ref[this_type] this.i = value.i;
 
-  handler this - Int : Int return this.i - value;
-  handler this * Int : this_type {
-    def ret: this_type;
-    ret.i = this.i * value;
-    return ret;
-  };
+    handler this < Int return this.i < value;
 
-  handler this << Int : Int { return this.i << value };
+    handler this - Int : Int return this.i - value;
+    handler this * Int : this_type {
+        def ret: this_type;
+        ret.i = this.i * value;
+        return ret;
+    };
 
-  handler this $ Int : Int return this.i $ value;
+    handler this << Int : Int { return this.i << value };
 
-  handler this~cast[Int] return this.i;
+    handler this $ Int : Int return this.i $ value;
 
-  handler this():Int return this.i;
+    handler this~cast[Int] return this.i;
 
-  handler this(Int) this.i += value;
+    handler this():Int return this.i;
 
-  handler this(f: float) => Float[64] {
-    return this.i + f;
-  };
+    handler this(Int) this.i += value;
+
+    handler this(f: float) => Float[64] {
+        return this.i + f;
+    };
+
+    handler this.myprop = Int { this.j = value; return this.j }
+
+    handler this.myprop += (v:Int) { this.j += v; return this.j }
+    handler this.myprop /= (v:Int) { this.j /= v; return this.j }
+
+    handler this.myprop = ref[this_type] { this.j = value.j; return this }
+
+    handler this.myprop < Int return this.j < value;
+
+    handler this.myprop - Int : Int return this.j - value;
+    handler this.myprop * Int : this_type {
+        def ret: this_type;
+        ret.j = this.j * value;
+        return ret;
+    };
+
+    handler this.myprop << Int : Int { return this.j << value };
+
+    handler this.myprop $ Int : Int return this.j $ value;
+
+    handler this.myprop:Int return this.j;
+
+    handler this.myprop():Int return this.j;
+
+    handler this.myprop(Int) this.j += value;
+
+    handler this.myprop(f: float) => Float[64] {
+        return this.j + f;
+    };
 };
 
 def t: T;
@@ -80,6 +117,46 @@ t(3);
 print("t(3) ==> t.i: %d\n", t.i);
 
 print("t(4.5) ==> %f\n", t(4.5));
+
+t.myprop = 3;
+print("t.myprop = 3 ==> t.j: %d\n", t.j);
+
+t2.myprop = t;
+print("t2.myprop = t ==> t2.j: %d\n", t2.j);
+
+t2.myprop = t.myprop = 5;
+print("t2.myprop = t.myprop = 5 ==> t.j: %d, t2.j: %d\n", t.j, t2.j);
+
+t.myprop += 3;
+print("t.myprop += 3 ==> t.j: %d\n", t.j);
+
+t.myprop /= 2;
+print("t.myprop /= 2 ==> t.j: %d\n", t.j);
+
+if t.myprop < 10 print("t.myprop is < 10\n");
+
+print("t.myprop - 3 ==> %d\n", t.myprop - 3);
+
+t3.myprop = t.myprop * 3;
+print("t3.myprop = t.myprop * 3 ==> t3.j: %d\n", t3.j);
+
+print("t.myprop << 2 ==> %d\n", t.myprop << 2);
+
+print("t.myprop $ 5 ==> %d\n", t.myprop $ 5);
+
+print("t.myprop~cast[Int] ==> %d\n", t.myprop~cast[Int]);
+i = t.myprop;
+print("i:Int = t.myprop ==> %d\n", i);
+
+printInt(t.myprop);
+printInt(rt.myprop);
+
+print("t.myprop() ==> %d\n", t.myprop());
+
+t.myprop(3);
+print("t.myprop(3) ==> t.j: %d\n", t.j);
+
+print("t.myprop(4.5) ==> %f\n", t.myprop(4.5));
 
 type Other {
   def j: Int;

--- a/Sources/Tests/Spp/Running/type_ops_test.alusus.output
+++ b/Sources/Tests/Spp/Running/type_ops_test.alusus.output
@@ -15,7 +15,24 @@ printInt(t) ==> 4
 t() ==> 4
 t(3) ==> t.i: 7
 t(4.5) ==> 11.500000
-ERROR SPPG1002 @ (89,1): Invalid operation.
-ERROR SPPG1002 @ (90,1): Invalid operation.
-ERROR SPPA1008 @ (91,1): Provided arguments do not match signature.
-ERROR SPPA1005 @ (96,3): Multiple matches were found for the given callee.
+t.myprop = 3 ==> t.j: 3
+t2.myprop = t ==> t2.j: 3
+t2.myprop = t.myprop = 5 ==> t.j: 5, t2.j: 5
+t.myprop += 3 ==> t.j: 8
+t.myprop /= 2 ==> t.j: 4
+t.myprop is < 10
+t.myprop - 3 ==> 1
+t3.myprop = t.myprop * 3 ==> t3.j: 12
+t.myprop << 2 ==> 16
+t.myprop $ 5 ==> 1
+t.myprop~cast[Int] ==> 4
+i:Int = t.myprop ==> 4
+printInt(t) ==> 4
+printInt(t) ==> 4
+t.myprop() ==> 4
+t.myprop(3) ==> t.j: 7
+t.myprop(4.5) ==> 11.500000
+ERROR SPPG1002 @ (166,1): Invalid operation.
+ERROR SPPG1002 @ (167,1): Invalid operation.
+ERROR SPPA1008 @ (168,1): Provided arguments do not match signature.
+ERROR SPPA1005 @ (173,3): Multiple matches were found for the given callee.


### PR DESCRIPTION
* Added support for defining named operator functions in user types, i.e. operator functions that have names which are the properties on which the operator is applied (rather than applying the operator on the type itself). For example, `this.prop + value` rather than `this + value`.
* Updated the `handler` command to support defining named operator functions.
* Cleaned up the callee lookup code.
* Cleaned up the way Seeker flags are implemented.
* Some minor performance improvements.
* Updated github workflow to fix the build.