### PR TITLE
Support this_type() operator.

### DIFF
--- a/Sources/Spp/Handlers/TypeHandlersParsingHandler.h
+++ b/Sources/Spp/Handlers/TypeHandlersParsingHandler.h
@@ -93,7 +93,7 @@ class TypeHandlersParsingHandler : public Core::Processing::Handlers::GenericPar
   );
 
   private: TioSharedPtr createFunction(
-    Processing::ParserState *state, Char const *funcName, Char const *op,
+    Processing::ParserState *state, Char const *funcName, Char const *op, Bool member,
     SharedPtr<Core::Data::Ast::Map> const argTypes, TioSharedPtr const &retType, TioSharedPtr const &body,
     SharedPtr<Core::Data::SourceLocation> const &sourceLocation, Mode mode
   );
@@ -104,13 +104,13 @@ class TypeHandlersParsingHandler : public Core::Processing::Handlers::GenericPar
   );
 
   private: Bool getThisAndPropIdentifiers(
-    Processing::ParserState *state, TiObject *astNode,
+    Processing::ParserState *state, TiObject *astNode, Bool allowThisType,
     Core::Data::Ast::Identifier *&thisIdentifier, SharedPtr<Core::Data::Ast::ParamPass> &thisType,
     Core::Data::Ast::Identifier *&propIdentifier
   );
 
   private: Bool getThisIdentifierAndType(
-    Processing::ParserState *state, TiObject *astNode,
+    Processing::ParserState *state, TiObject *astNode, Bool allowThisType,
     Core::Data::Ast::Identifier *&thisIdentifier, SharedPtr<Core::Data::Ast::ParamPass> &thisType
   );
 

--- a/Sources/Tests/Spp/Parsing/type_ops_test.alusus
+++ b/Sources/Tests/Spp/Parsing/type_ops_test.alusus
@@ -102,6 +102,10 @@ type T {
   handler (that:Parent)() {}
   handler (that:Parent).prop() {}
   handler (this->Parent).prop() {}
+
+  handler this_type() {}
+  handler this_type(): ref[T] {}
+  handler this_type(n: Int): ref[T] {}
 };
 
 dump_ast T;

--- a/Sources/Tests/Spp/Parsing/type_ops_test.alusus.output
+++ b/Sources/Tests/Spp/Parsing/type_ops_test.alusus.output
@@ -781,4 +781,39 @@ UserType [Main.Type]
        b: Identifier: Int [Main.BlockSubject.Identifier]
       retType: NULL
      body: Block [Main.BlockStatements.StmtList]
+  Definition [Main.LeadingCmdGrp] ()
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: ()
+   target: Function 
+     type: FunctionType member: 0
+      argTypes: Map
+      retType: NULL
+     body: Block [Main.BlockStatements.StmtList]
+  Definition [Main.LeadingCmdGrp] ()
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: ()
+   target: Function 
+     type: FunctionType member: 0
+      argTypes: Map
+      retType: ParamPass [] [Main.Expression.ParamPassExp]
+       operand: Identifier: ref [Main.BlockSubject.Identifier]
+       param: Identifier: T [Main.BlockSubject.Identifier]
+     body: Block [Main.BlockStatements.StmtList]
+  Definition [Main.LeadingCmdGrp] ()
+   modifiers:
+    ParamPass []
+     operand: Identifier: operation
+     param: StringLiteral: ()
+   target: Function 
+     type: FunctionType member: 0
+      argTypes: Map
+       n: Identifier: Int [Main.BlockSubject.Identifier]
+      retType: ParamPass [] [Main.Expression.ParamPassExp]
+       operand: Identifier: ref [Main.BlockSubject.Identifier]
+       param: Identifier: T [Main.BlockSubject.Identifier]
+     body: Block [Main.BlockStatements.StmtList]
 ------------------------------------------------------

--- a/Sources/Tests/Spp/Running/type_parens_test.alusus
+++ b/Sources/Tests/Spp/Running/type_parens_test.alusus
@@ -1,0 +1,110 @@
+import "Srl/Console";
+use Srl;
+
+type A {
+    def i: Int;
+
+    handler this~init() {
+        this.i = 2;
+        Console.print("A~init\n");
+    }
+
+    handler this~terminate() {
+        Console.print("A~terminate\n");
+    }
+
+    handler this_type(): ref[A] {
+        @shared def a: A;
+        a.i = 1;
+        Console.print("A()\n");
+        return a;
+    }
+}
+
+type B {
+    def i: Int;
+
+    handler this~init(n: Int) {
+        this.i = n;
+        Console.print("B~init\n");
+    }
+
+    handler this~terminate() {
+        Console.print("B~terminate\n");
+    }
+
+    handler this_type(): ref[B] {
+        @shared def b: B(3);
+        Console.print("B()\n");
+        return b;
+    }
+}
+
+type C {
+    def i: Int;
+
+    handler this~init(n: Int) {
+        this.i = n;
+        Console.print("C~init\n");
+    }
+
+    handler this~terminate() {
+        Console.print("C~terminate\n");
+    }
+
+    handler this_type(n: Int): ref[C] {
+        @shared def c: C(0);
+        c.i = n;
+        Console.print("C()\n");
+        return c;
+    }
+}
+
+type D {
+    def i: Int;
+
+    handler this_type(n: Int): ref[D] {
+        @shared def d: D(0);
+        d.i = n;
+        Console.print("D()\n");
+        return d;
+    }
+}
+
+func test1 {
+    Console.print("test1\n");
+    Console.print("%d\n", A().i);
+}
+test1();
+
+Console.print("\n");
+
+func test2 {
+    Console.print("test2\n");
+    def a: A;
+    Console.print("%d\n", a.i);
+}
+test2();
+
+Console.print("\n");
+
+func test3 {
+    Console.print("test3\n");
+    Console.print("%d\n", B().i);
+}
+test3();
+
+Console.print("\n");
+
+func test4 {
+    Console.print("test4\n");
+    Console.print("%d\n", C(4).i);
+}
+test4();
+
+func testErrors {
+    Console.print("testErrors\n");
+    Console.print("%d\n", C("4").i);
+    Console.print("%d\n", D("4").i);
+}
+testErrors();

--- a/Sources/Tests/Spp/Running/type_parens_test.alusus.output
+++ b/Sources/Tests/Spp/Running/type_parens_test.alusus.output
@@ -1,0 +1,21 @@
+A~init
+test1
+A()
+1
+
+test2
+A~init
+2
+A~terminate
+
+B~init
+test3
+B()
+3
+
+C~init
+test4
+C()
+4
+ERROR SPPA1008 @ (107,27): Provided arguments do not match signature.
+ERROR SPPA1008 @ (108,27): Provided arguments do not match signature.


### PR DESCRIPTION
This operator allows overriding the syntax for instantiating temp variables, so using () on a type would call a function instead of instantiating a temp variable.