### PR TITLE
Renamed type keyword to class.

### DIFF
--- a/Examples/General/hex_to_rgba.alusus
+++ b/Examples/General/hex_to_rgba.alusus
@@ -19,7 +19,7 @@ func parseHex (hex: ptr[array[Char]], len: Int): Int {
     return result;
 }
 
-type Rgba {
+class Rgba {
     def r: Word[8];
     def g: Word[8];
     def b: Word[8];

--- a/Examples/General/user_types.alusus
+++ b/Examples/General/user_types.alusus
@@ -1,7 +1,7 @@
 import "Srl/Console";
 use Srl;
 
-type Point {
+class Point {
   def x: Int;
   def y: Int;
 }

--- a/Sources/Spp/GrammarFactory.cpp
+++ b/Sources/Spp/GrammarFactory.cpp
@@ -38,7 +38,7 @@ void GrammarFactory::createGrammar()
     S("break"), S("اقطع"),
     S("return"), S("أرجع"), S("ارجع"),
     S("module"), S("وحدة"),
-    S("type"), S("صنف"),
+    S("class"), S("type"), S("صنف"),
     S("func"), S("function"), S("دالّة"), S("دالة"),
     S("macro"), S("ماكرو"),
     S("preprocess"), S("تمهيد"),
@@ -298,9 +298,9 @@ void GrammarFactory::createGrammar()
     {S("handler"), ScopeParsingHandler<Spp::Ast::Module>::create(this->rootManager->getSeeker())}
   }).get());
 
-  //// type = "type" + Set
+  //// type = "class" + Set
   this->createCommand(S("root.Main.Type"), {{
-    Map::create({}, { { S("type"), 0 }, { S("صنف"), 0 } }),
+    Map::create({}, { { S("class"), 0 }, { S("صنف"), 0 } }),
     {
       {
         PARSE_REF(S("module.ParamOnlySubject")),
@@ -817,7 +817,7 @@ void GrammarFactory::cleanGrammar()
     S("break"), S("اقطع"),
     S("return"), S("أرجع"), S("ارجع"),
     S("module"), S("وحدة"),
-    S("type"), S("صنف"),
+    S("class"), S("type"), S("صنف"),
     S("func"), S("function"), S("دالّة"), S("دالة"),
     S("macro"), S("ماكرو"),
     S("preprocess"), S("تمهيد"),

--- a/Sources/Srt/Build.alusus
+++ b/Sources/Srt/Build.alusus
@@ -39,7 +39,7 @@ if Srl.String.compare(Process.language, "ar") == 0 {
         return result != 0;
     }
 
-    type Unit {
+    class Unit {
         def element: ref[TiObject];
         def outputFilename: CharsPtr;
         def deps: Array[String];
@@ -87,7 +87,7 @@ if Srl.String.compare(Process.language, "ar") == 0 {
         }
     }
 
-    type Exe {
+    class Exe {
         @injection def unit: Unit;
 
         handler this~init(e: ref[TiObject], fn: CharsPtr) {
@@ -137,7 +137,7 @@ if Srl.String.compare(Process.language, "ar") == 0 {
         }
     }
 
-    type Wasm {
+    class Wasm {
         @injection def unit: Unit;
 
         handler this~init(e: ref[TiObject], fn: CharsPtr) {

--- a/Sources/Srt/Core/Basic.alusus
+++ b/Sources/Srt/Core/Basic.alusus
@@ -31,7 +31,7 @@ import "Srl/String";
             }
         }
 
-        type TiObjectFactory {
+        class TiObjectFactory {
             def createPlain: ptr[function ():ref[TiObject]];
             def createShared: ptr[function ():SrdRef[TiObject]];
             def initialize: ptr[function (ref[TiObject])];
@@ -39,7 +39,7 @@ import "Srl/String";
             def getSize: ptr[function ():ArchInt];
         }
 
-        type TypeInfo {
+        class TypeInfo {
             def typeName: String;
             def typeNamespace: String;
             def packageName: String;
@@ -49,7 +49,7 @@ import "Srl/String";
             def objectFactory: ref[TiObjectFactory];
         }
 
-        type TiObject {
+        class TiObject {
             def vtable: ptr;
             def wkThis: WkRef[this_type];
 
@@ -63,7 +63,7 @@ import "Srl/String";
             handler this.getInterface (ref[TypeInfo]): ref[TiInterface];
         }
 
-        type TiInterface {
+        class TiInterface {
             def vtable: ptr;
 
             @expname[TiInterface_getMyInterfaceInfo]
@@ -116,7 +116,7 @@ import "Srl/String";
         };
 
         macro defTiBasicType [name, dataType, uniqueName] {
-            type name {
+            class name {
                 @injection def tiObject: TiObject;
                 def value: dataType;
                 handler this~init() {
@@ -142,7 +142,7 @@ import "Srl/String";
         }
 
         macro addExtraInitializer [name, dataType] {
-            @merge type name {
+            @merge class name {
                 handler this~init(v: dataType) {
                     getTypeInfo().objectFactory.initialize(this);
                     this.value = v;
@@ -164,7 +164,7 @@ import "Srl/String";
         defTiBasicType[TiStr, String, "alusus.org/Core/Core.Basic.TiStrBase<alusus.org/Core/Core.Basic.TiObject>"];
         addExtraInitializer[TiStr, ptr[array[Char]]];
 
-        type Binding {
+        class Binding {
             @injection def tiInterface: TiInterface;
 
             @expname[Binding_setMemberByName]
@@ -197,7 +197,7 @@ import "Srl/String";
             defTypeInfoGetter["alusus.org/Core/Core.Basic.Binding"]
         }
 
-        type Containing {
+        class Containing {
             @injection def tiInterface: TiInterface;
 
             @expname[Containing_setElement]
@@ -215,7 +215,7 @@ import "Srl/String";
             defTypeInfoGetter["alusus.org/Core/Core.Basic.Containing<alusus.org/Core/Core.Basic.TiObject>"]
         }
 
-        type DynamicContaining {
+        class DynamicContaining {
             @injection def containing: Containing;
 
             @expname[DynamicContaining_addElement]
@@ -233,7 +233,7 @@ import "Srl/String";
             defTypeInfoGetter["alusus.org/Core/Core.Basic.DynamicContaining<alusus.org/Core/Core.Basic.TiObject>"]
         }
 
-        type MapContaining {
+        class MapContaining {
             @injection def containing: Containing;
 
             @expname[MapContaining_setElement]
@@ -254,7 +254,7 @@ import "Srl/String";
             defTypeInfoGetter["alusus.org/Core/Core.Basic.MapContaining<alusus.org/Core/Core.Basic.TiObject>"]
         }
 
-        type DynamicMapContaining {
+        class DynamicMapContaining {
             @injection def mapContaining: MapContaining;
 
             @expname[DynamicMapContaining_addElement]

--- a/Sources/Srt/Core/Data.alusus
+++ b/Sources/Srt/Core/Data.alusus
@@ -19,7 +19,7 @@ import "Srl/String";
     module Data {
         use Basic;
 
-        type Node {
+        class Node {
             @injection def tiObject: TiObject;
             def owner: ref[Node];
 
@@ -28,7 +28,7 @@ import "Srl/String";
 
         module Ast {
             macro defTextAstType [name, uniqueName] {
-                type name {
+                class name {
                     @injection def node: Node;
                     def binding: TiInterface;
                     def metaHaving: TiInterface;
@@ -78,7 +78,7 @@ import "Srl/String";
             defTextAstType[StringLiteral, "alusus.org/Core/Core.Data.Ast.StringLiteral"];
 
             macro defAstType[name, uniqueName] {
-                type name {
+                class name {
                     @injection def node: Core.Data.Node;
 
                     preprocess {

--- a/Sources/Srt/Spp.alusus
+++ b/Sources/Srt/Spp.alusus
@@ -29,7 +29,7 @@ import "Srl/refs";
         def GLOBAL: 2;
     };
 
-    type GrammarMgr {
+    class GrammarMgr {
         @expname[Spp_GrammarMgr_addCustomCommand]
         handler this.addCustomCommand (
             qualifier: ptr[array[Char]], grammarAst: ref[Core.Basic.TiObject],
@@ -38,7 +38,7 @@ import "Srl/refs";
     };
     def grammarMgr: ref[GrammarMgr];
 
-    type AstMgr {
+    class AstMgr {
         @expname[Spp_AstMgr_findElements]
         handler this.findElements(
             comparison: ref[Core.Basic.TiObject],
@@ -130,7 +130,7 @@ import "Srl/refs";
     };
     def astMgr: ref[AstMgr];
 
-    type BuildMgr {
+    class BuildMgr {
         @expname[Spp_BuildMgr_dumpLlvmIrForElement]
         handler this.dumpLlvmIrForElement (element: ref[Core.Basic.TiObject]);
 

--- a/Sources/Srt/Srl/Array.alusus
+++ b/Sources/Srt/Srl/Array.alusus
@@ -14,7 +14,7 @@ import "Memory";
 
 @merge module Srl
 {
-    type Array [T: type] {
+    class Array [T: type] {
         //=================
         // Member Variables
 
@@ -164,7 +164,7 @@ import "Memory";
     //==========================================================================
     // Internal Types
 
-    type ArrayData [T: type] {
+    class ArrayData [T: type] {
         //=================
         // Member Variables
 

--- a/Sources/Srt/Srl/ArrayIndex.alusus
+++ b/Sources/Srt/Srl/ArrayIndex.alusus
@@ -15,7 +15,7 @@ import "System";
 import "Memory";
 
 @merge module Srl {
-    type ArrayIndex [T: type] {
+    class ArrayIndex [T: type] {
         //=================
         // Member Variables
 

--- a/Sources/Srt/Srl/Fs.alusus
+++ b/Sources/Srt/Srl/Fs.alusus
@@ -20,16 +20,16 @@ import "String";
   {
     def FILENAME_LENGTH: 256;
 
-    def File: type {};
-    def Dir: type {};
-    def DirEnt: type {
+    def File: class {};
+    def Dir: class {};
+    def DirEnt: class {
       def ino: Int[64];
       def off: Int[64];
       def reclen: Int[16];
       def dType: Int[8];
       def dName: array[Char, FILENAME_LENGTH];
     };
-    def FileNames: type {
+    def FileNames: class {
       def count: Int;
       def names: array[array[Char, FILENAME_LENGTH]];
     };

--- a/Sources/Srt/Srl/Map.alusus
+++ b/Sources/Srt/Srl/Map.alusus
@@ -16,7 +16,7 @@ import "System";
 
 @merge module Srl
 {
-    type Map [T1: type, T2: type] {
+    class Map [T1: type, T2: type] {
         //=================
         // Member Variables
 

--- a/Sources/Srt/Srl/Net.alusus
+++ b/Sources/Srt/Srl/Net.alusus
@@ -18,7 +18,7 @@ import "curl";
 {
   def Net: module
   {
-    type Curl {
+    class Curl {
       func exec(curlHandle: ptr[Curl], resultCount: ptr[Int], responseCode: ptr[Int]): ptr {
         def result: ptr = 0;
 
@@ -54,7 +54,8 @@ import "curl";
         return exec(curlHandle, resultCount~ptr, responseCode~ptr);
       }
     };
-    type CurlInfo {};
+
+    class CurlInfo {};
 
     module CurlOpt {
       def WRITEDATA: 10001;
@@ -317,7 +318,7 @@ import "curl";
       func reset(curl: ptr[Curl]);
     };
 
-    type CurlSlist {
+    class CurlSlist {
       @expname[curl_slist_append]
       func append(curlSlist: ptr[CurlSlist], string: ptr[array[Char]]): ptr[CurlSlist];
 
@@ -334,7 +335,7 @@ import "curl";
       func freeAll(curlSlist: ptr[CurlSlist]): Void;
     };
 
-    type _Content {
+    class _Content {
       def data: ptr[array[Word[8]]];
       def size: Int;
     };

--- a/Sources/Srt/Srl/Regex.alusus
+++ b/Sources/Srt/Srl/Regex.alusus
@@ -17,7 +17,7 @@ import "Spp";
 
 @merge module Srl {
   module Regex {
-    type Context {
+    class Context {
       def buffer: ptr[array[Char]];
       def allocated: Word[64];
       def used: Word[64];
@@ -28,7 +28,7 @@ import "Spp";
       def flags: Word[64];
     };
 
-    type Match {
+    class Match {
         preprocess {
             if String.isEqual(Process.platform, "macos") {
                 Spp.astMgr.insertAst(

--- a/Sources/Srt/Srl/String.alusus
+++ b/Sources/Srt/Srl/String.alusus
@@ -16,7 +16,7 @@ import "Array";
 
 @merge module Srl
 {
-    type StringBase [T: type] {
+    class StringBase [T: type] {
         //============
         // Member Vars
 
@@ -437,7 +437,7 @@ import "Array";
 {
     def String: alias StringBase[Char];
 
-    @merge type String {
+    @merge class String {
         handler this.append (i: Int[64]) {
             this._append(i, 1);
         }

--- a/Sources/Srt/Srl/Time.alusus
+++ b/Sources/Srt/Srl/Time.alusus
@@ -14,7 +14,7 @@ import "srl";
 
 @merge module Srl {
     module Time {
-        type DetailedTime {
+        class DetailedTime {
             def second: Int;
             def minute: Int;
             def hour: Int;

--- a/Sources/Srt/Srl/WString.alusus
+++ b/Sources/Srt/Srl/WString.alusus
@@ -16,7 +16,7 @@ import "String";
 {
     def WString: alias StringBase[Char];
 
-    @merge type WString {
+    @merge class WString {
         @expname[wcschr]
         func find(s: ptr[Word], c: Word): ptr[Word];
 

--- a/Sources/Srt/Srl/refs.alusus
+++ b/Sources/Srt/Srl/refs.alusus
@@ -19,7 +19,7 @@ import "Spp";
     //==========================================================================
     // RefCounter
     // A ref counting object to be used by the shared references.
-    type RefCounter {
+    class RefCounter {
         def count: Int;
         def singleAllocation: Bool;
         def terminator: ptr[function (p: ptr)];
@@ -76,7 +76,7 @@ import "Spp";
     //==========================================================================
     // SharedRef
     // Shared Reference
-    type SrdRef [T: type] {
+    class SrdRef [T: type] {
         //=================
         // Member Variables
 
@@ -202,7 +202,7 @@ import "Spp";
     //==========================================================================
     // WkRef
     // Weak Reference
-    type WkRef [T: type] {
+    class WkRef [T: type] {
         //=================
         // Member Variables
 
@@ -270,7 +270,7 @@ import "Spp";
     //==========================================================================
     // UnqRef
     // Unique Reference
-    type UnqRef [T: type] {
+    class UnqRef [T: type] {
         //=================
         // Member Variables
 

--- a/Sources/Srt/Zip.alusus
+++ b/Sources/Srt/Zip.alusus
@@ -16,7 +16,7 @@ import "Core";
 import "libzip.so" or "libzip.dylib";
 
 def Zip: module {
-  def zip_t: type {};
+  def zip_t: class {};
   def _zip_entry_open: @expname[zip_entry_open] function(archive: ptr[zip_t], filename: ptr[array[Char]]);
   def _zip_entry_write: @expname[zip_entry_write] function(
     archive: ptr[zip_t], content: ptr[array[Char]], contentLength: Int

--- a/Sources/Srt/closure.alusus
+++ b/Sources/Srt/closure.alusus
@@ -14,7 +14,7 @@ module Closures {
 
     def AstTemplateMap: alias Map[String, ref[TiObject]];
 
-    type Closure [FnType:type] {
+    class Closure [FnType:type] {
         preprocess {
             fillClosureBody(FnType~ast);
         }
@@ -124,7 +124,7 @@ module Closures {
         Spp.astMgr.insertAst(
             ast {
                 Closures.Closure[closureArgFnType]().{
-                    type Data {
+                    class Data {
                         payloadDefs
                     }
                     def d: Srl.SrdRef[Data];

--- a/Sources/Tests/Spp/Building/arrays_test.alusus
+++ b/Sources/Tests/Spp/Building/arrays_test.alusus
@@ -4,13 +4,13 @@ def Main: module
 {
   def print: @expname[printf] function (fmt: ptr[Word[8]], args: ...any)=>Int[64];
 
-  def T: type
+  def T: class
   {
     def x: Int[32];
     def y: Int[32];
   };
 
-  def TA: type
+  def TA: class
   {
     def i: Int[32];
     def ai: array[Int[32], 4];

--- a/Sources/Tests/Spp/Building/ast_processing_test.alusus
+++ b/Sources/Tests/Spp/Building/ast_processing_test.alusus
@@ -11,7 +11,7 @@ module MyMod {
   }
 };
 
-type Point {
+class Point {
   defInt[x];
   handler this.getDouble() { return this.x * 2 }
   preprocess {
@@ -71,7 +71,7 @@ dump_ast testAstLiteral2;
 // Testing double preprocessing, i.e. cases where the same preprocess statement is triggered twice due to a dependency
 // using the same element currently being preprocessed.
 
-type A {
+class A {
     def i: Int;
     preprocess {
         print("A->preprocess\n");

--- a/Sources/Tests/Spp/Building/auto_pass_by_ref_test.alusus
+++ b/Sources/Tests/Spp/Building/auto_pass_by_ref_test.alusus
@@ -1,11 +1,11 @@
 import "defs-ignore.alusus";
 
-type Point1 {
+class Point1 {
   def x: Int;
   def y: Int;
 };
 
-type Point2 {
+class Point2 {
   def x: Int;
   def y: Int;
   handler this~init() {};

--- a/Sources/Tests/Spp/Building/custom_caster_test.alusus
+++ b/Sources/Tests/Spp/Building/custom_caster_test.alusus
@@ -1,11 +1,11 @@
 import "defs-ignore.alusus";
 
-type T1 {
+class T1 {
   def i: Int;
   handler this~cast[Int] return this.i;
 };
 
-type T2 {
+class T2 {
   def i: Int;
   handler this~cast[Int] {};
 };

--- a/Sources/Tests/Spp/Building/custom_init_test.alusus
+++ b/Sources/Tests/Spp/Building/custom_init_test.alusus
@@ -1,7 +1,7 @@
 import "defs-ignore.alusus";
 import "Srl/Console.alusus";
 
-type A
+class A
 {
   def i: Int;
 
@@ -21,13 +21,13 @@ type A
   };
 };
 
-type B
+class B
 {
   def a: A;
   def a2: A;
 };
 
-type C
+class C
 {
   def i: Int;
   Srl.Console.print("C constructed!\n");

--- a/Sources/Tests/Spp/Building/defs-ignore.alusus
+++ b/Sources/Tests/Spp/Building/defs-ignore.alusus
@@ -1,11 +1,11 @@
 import "alusus_spp";
 module Core {
     module Basic {
-        type TiObject {}
+        class TiObject {}
     }
 }
 module Spp {
-    type BuildMgr {
+    class BuildMgr {
         @expname[Spp_BuildMgr_dumpLlvmIrForElement]
         handler this.dumpLlvmIrForElement (element: ref[Core.Basic.TiObject]);
     };

--- a/Sources/Tests/Spp/Building/eval_statement_test.alusus
+++ b/Sources/Tests/Spp/Building/eval_statement_test.alusus
@@ -57,7 +57,7 @@ func testAstInsertion {
 
 Spp.buildMgr.dumpLlvmIrForElement(testAstInsertion~ast);
 
-type A {
+class A {
     def i: Int;
     handler this~init() {
         this.i = 1;

--- a/Sources/Tests/Spp/Building/function_pointers_test.alusus
+++ b/Sources/Tests/Spp/Building/function_pointers_test.alusus
@@ -33,7 +33,7 @@ def Main: module
     print("%d\n", getFunc2()(pf));
   };
 
-  def Rec: type
+  def Rec: class
   {
     def pget: ptr[function ()=>Int[32]];
     def pmul: ptr[function (n: Int[32])=>Int[32]];

--- a/Sources/Tests/Spp/Building/global_constructors_test.alusus
+++ b/Sources/Tests/Spp/Building/global_constructors_test.alusus
@@ -1,7 +1,7 @@
 import "defs-ignore.alusus";
 def print: @expname[printf] function (fmt: ptr[Word[8]], args: ...any)=>Int[64];
 
-type A {
+class A {
     def i: Int;
     handler this~init() {
         print("A~init\n");

--- a/Sources/Tests/Spp/Building/init_tilde_test.alusus
+++ b/Sources/Tests/Spp/Building/init_tilde_test.alusus
@@ -1,6 +1,6 @@
 import "defs-ignore.alusus";
 
-type T {
+class T {
   def i: Int;
 
   handler this~init() {};

--- a/Sources/Tests/Spp/Building/injection_test.alusus
+++ b/Sources/Tests/Spp/Building/injection_test.alusus
@@ -3,13 +3,13 @@ import "Srl/Console.alusus";
 
 use Srl.Console;
 
-type InnerMost {
+class InnerMost {
   def a: Int;
   handler this.getA():Int { return this.a }
   handler this=Int { this.a = value };
 }
 
-type Inner {
+class Inner {
   @injection def rim: ref[InnerMost];
 
   def i: Int;
@@ -17,7 +17,7 @@ type Inner {
   handler this(): Int { return this.i * 2 }
 }
 
-type Outer {
+class Outer {
   @injection def inner: Inner;
   def k: Int;
   a = 6;

--- a/Sources/Tests/Spp/Building/macros_errors_test.alusus
+++ b/Sources/Tests/Spp/Building/macros_errors_test.alusus
@@ -11,7 +11,7 @@ def defGetMin: macro [n, T] {
 
 def Main: module
 {
-  def MyType: type
+  def MyType: class
   {
     defGetMin[b, Int];
   }

--- a/Sources/Tests/Spp/Building/macros_test.alusus
+++ b/Sources/Tests/Spp/Building/macros_test.alusus
@@ -18,7 +18,7 @@ def loop: macro[counter, start, end, action] {
   for counter = start, counter <= end, ++counter action;
 };
 def defType: macro[name, var1, var2, Type] {
-  def name: type {
+  def name: class {
     def var1: Type;
     def var2: Type;
   };

--- a/Sources/Tests/Spp/Building/member_functions_test.alusus
+++ b/Sources/Tests/Spp/Building/member_functions_test.alusus
@@ -2,7 +2,7 @@ import "defs-ignore.alusus";
 
 @expname[printf] func print(format: ptr[Word[8]], args: ...any): Int[32];
 
-type A
+class A
 {
   def i: Int;
 
@@ -19,7 +19,7 @@ type A
   };
 };
 
-type B
+class B
 {
   def a: A;
   def f: ptr[function];
@@ -68,7 +68,7 @@ function getBRef ():ref[B] {
   return b;
 };
 
-type C
+class C
 {
   def i: Int;
 

--- a/Sources/Tests/Spp/Building/parameterized_ctors_test.alusus
+++ b/Sources/Tests/Spp/Building/parameterized_ctors_test.alusus
@@ -1,6 +1,6 @@
 import "defs-ignore.alusus";
 
-type A {
+class A {
     def i: Int;
 
     handler this~init(n: Int) {
@@ -18,7 +18,7 @@ type A {
     }
 }
 
-type B {
+class B {
     def a: A(4, 5, 6, 7, 8);
 }
 

--- a/Sources/Tests/Spp/Building/pointer_member_functions_test.alusus
+++ b/Sources/Tests/Spp/Building/pointer_member_functions_test.alusus
@@ -2,11 +2,11 @@ import "defs-ignore.alusus";
 import "Srl/Console";
 use Srl;
 
-type N_vtable {
+class N_vtable {
     def printIt: ptr[@member func(this: ref[N])];
 }
 
-type N {
+class N {
     @shared def vtable: N_vtable;
     @no_bind @injection def vtableRef: ref[N_vtable];
     vtableRef~no_deref = vtable;
@@ -17,7 +17,7 @@ type N {
     vtableRef.printIt = printItImpl~ptr;
 }
 
-type N2 {
+class N2 {
     @shared def vtable: N_vtable;
     @injection def super: N;
     vtableRef~no_deref = vtable;
@@ -46,7 +46,7 @@ Spp.buildMgr.dumpLlvmIrForElement(test1~ast);
 
 Console.print("\n");
 
-type M {
+class M {
     def i: Int;
 
     func printItImpl (this: ref[M]) {

--- a/Sources/Tests/Spp/Building/references_test.alusus
+++ b/Sources/Tests/Spp/Building/references_test.alusus
@@ -156,7 +156,7 @@ Spp.buildMgr.dumpLlvmIrForElement(getObjectFromRefRef~ast);
 // ~deref & ~no_deref
 //
 
-type A {
+class A {
     def i: Int;
     handler this~init() {
         this.i = 7;
@@ -199,12 +199,12 @@ function receiveIntRef (r: ref[Int]) {
     print("receiveIntRef: %d\n", r);
 }
 
-type B {
+class B {
     def i: Int;
     handler this=temp_ref[Int] this.i = value;
 };
 
-type C {
+class C {
     def i: Int;
     handler this=ref[Int] this.i = value;
 };

--- a/Sources/Tests/Spp/Building/shared_defs_test.alusus
+++ b/Sources/Tests/Spp/Building/shared_defs_test.alusus
@@ -9,7 +9,7 @@ def Main: module
 {
   def print: alias Std.printf;
 
-  def MyType: type
+  def MyType: class
   {
     def x: Int;
     def ax: array[Int, 1];

--- a/Sources/Tests/Spp/Building/temp_objs_test.alusus
+++ b/Sources/Tests/Spp/Building/temp_objs_test.alusus
@@ -2,7 +2,7 @@ import "defs-ignore.alusus";
 import "Srl/Console";
 use Srl;
 
-type A {
+class A {
     def i: Int;
     handler this~init() {
         this.i = 7;
@@ -15,7 +15,7 @@ type A {
 }
 
 module M {
-    type B {
+    class B {
         def i: Int;
         handler this~init() {
             this.i = 8;
@@ -28,7 +28,7 @@ module M {
     }
 }
 
-type C {
+class C {
     def i: Int;
     handler this~init(n: Int) {
         this.i = n;
@@ -46,7 +46,7 @@ type C {
     }
 }
 
-type D {
+class D {
     def a: A;
 }
 
@@ -54,7 +54,7 @@ func varArgFunc(count: Int, args: ...Int) {
     Console.print("varArgFunc\n");
 }
 
-type E {
+class E {
     def i: Int = A().i;
     def j: C({ A().i, A().i, 5 });
     varArgFunc({ A().i, A().i, A().i });

--- a/Sources/Tests/Spp/Building/terminate_tilde_test.alusus
+++ b/Sources/Tests/Spp/Building/terminate_tilde_test.alusus
@@ -1,6 +1,6 @@
 import "defs-ignore.alusus";
 
-type T {
+class T {
   def i: Int;
 
   handler this~init() {};

--- a/Sources/Tests/Spp/Building/user_types_test.alusus
+++ b/Sources/Tests/Spp/Building/user_types_test.alusus
@@ -5,7 +5,7 @@ def Main: module
   def print: @expname[printf] function (fmt: ptr[Word[8]], args: ...any)=>Int[64];
   def i: Int;
 
-  def Point: type
+  def Point: class
   {
     def x: Int[32];
     def y: Int[32];
@@ -17,25 +17,25 @@ def Main: module
 
   def gpoint: Point;
 
-  def Nested: type
+  def Nested: class
   {
     def p: Point;
     def i: Int[8];
     def j: Int[16];
   };
 
-  def DeepNested: type
+  def DeepNested: class
   {
     def n: Nested;
     def k: Int[8];
     def l: Int[16];
   };
 
-  def Empty: type
+  def Empty: class
   {
   };
 
-  def Wrong: type
+  def Wrong: class
   {
     def w: Invalid
   };

--- a/Sources/Tests/Spp/Building/variables_test.alusus
+++ b/Sources/Tests/Spp/Building/variables_test.alusus
@@ -106,7 +106,7 @@ def Main: module
     print("%f\n", Other.Nested.gf);
   };
 
-  type MyType {
+  class MyType {
     @shared function init ():MyType {
       return MyType();
     }

--- a/Sources/Tests/Spp/Parsing/auto_casting_test.alusus
+++ b/Sources/Tests/Spp/Parsing/auto_casting_test.alusus
@@ -1,18 +1,18 @@
 import "alusus_spp";
-module Core { module Basic { type TiObject {} } }
+module Core { module Basic { class TiObject {} } }
 module Spp {
-    type BuildMgr {
+    class BuildMgr {
         @expname[Spp_BuildMgr_dumpLlvmIrForElement]
         handler this.dumpLlvmIrForElement (element: ptr);
     };
     def buildMgr: ref[BuildMgr];
 }
 
-type A {
+class A {
   def i: Int;
 }
 
-type B {
+class B {
   @injection def a: A;
 }
 

--- a/Sources/Tests/Spp/Parsing/modules_test.alusus
+++ b/Sources/Tests/Spp/Parsing/modules_test.alusus
@@ -20,7 +20,7 @@ def Module2: module {
   def c2: 3;
 };
 
-@merge def Module2: type {
+@merge def Module2: class {
   def d2: 4;
 };
 

--- a/Sources/Tests/Spp/Parsing/shared_defs_test.alusus
+++ b/Sources/Tests/Spp/Parsing/shared_defs_test.alusus
@@ -2,7 +2,7 @@ import "alusus_spp";
 
 def Main: module
 {
-  def MyType: type
+  def MyType: class
   {
     def x: Int;
     @shared def y: Int;

--- a/Sources/Tests/Spp/Parsing/template_type_test.alusus
+++ b/Sources/Tests/Spp/Parsing/template_type_test.alusus
@@ -1,6 +1,6 @@
 import "alusus_spp";
 
-type MyType [T: type, F: function, I: integer, S: string]
+class MyType [T: type, F: function, I: integer, S: string]
 {
   def t: T;
   F();
@@ -10,18 +10,18 @@ type MyType [T: type, F: function, I: integer, S: string]
 
 dump_ast MyType;
 
-type MyWrongType1 []
+class MyWrongType1 []
 {
 };
 
-type MyWrongType2 [T: type, ]
+class MyWrongType2 [T: type, ]
 {
 };
 
-type MyWrongType3 [T1: type, T2: wrong]
+class MyWrongType3 [T1: type, T2: wrong]
 {
 };
 
-type MyWrongType4 [T: type, T: function]
+class MyWrongType4 [T: type, T: function]
 {
 };

--- a/Sources/Tests/Spp/Parsing/template_type_test.alusus.output
+++ b/Sources/Tests/Spp/Parsing/template_type_test.alusus.output
@@ -20,7 +20,7 @@ Template
      param: Identifier: S [Main.BlockSubject.Identifier]
  -instances:
 ------------------------------------------------------
-ERROR SPPA1002 @ (13,19): Invalid template argument.
-ERROR SPPA1002 @ (17,19): Invalid template argument.
-ERROR SPPH1017 @ (21,30): Invalid templatae arg type.
-ERROR SPPH1016 @ (25,29): Invalid template arg name.
+ERROR SPPA1002 @ (13,20): Invalid template argument.
+ERROR SPPA1002 @ (17,20): Invalid template argument.
+ERROR SPPH1017 @ (21,31): Invalid templatae arg type.
+ERROR SPPH1016 @ (25,30): Invalid template arg name.

--- a/Sources/Tests/Spp/Parsing/test.alusus
+++ b/Sources/Tests/Spp/Parsing/test.alusus
@@ -7,7 +7,7 @@ def a: {"hello", "world"; i++ };
 def b: module {
   def c: 124;
   c = c + 1;
-  def t: type {
+  def t: class {
     def x: float;
     def y: float;
   };
@@ -24,7 +24,7 @@ def f: function (x:int, y:int)=>int {
   }
 };
 
-def t: type {
+def t: class {
   def i: float;
   def j: float;
   dump_ast b.t;

--- a/Sources/Tests/Spp/Parsing/type_ops_test.alusus
+++ b/Sources/Tests/Spp/Parsing/type_ops_test.alusus
@@ -1,6 +1,6 @@
 import "alusus_spp";
 
-type T {
+class T {
   def i: Int;
 
   handler this~init() {};

--- a/Sources/Tests/Spp/Parsing/user_types_test.alusus
+++ b/Sources/Tests/Spp/Parsing/user_types_test.alusus
@@ -2,17 +2,17 @@ import "alusus_spp";
 
 def Main: module
 {
-  def EmptyType: type
+  def EmptyType: class
   {
   };
 
-  def MyType: type
+  def MyType: class
   {
     def x: Int[32];
     def y: Int[32];
   };
 
-  def WrongType: type;
+  def WrongType: class;
 
   def start: function ()=>Void
   {
@@ -22,12 +22,12 @@ def Main: module
     print("x, y = %d, %d", v.x, v.y)
   };
 
-  def MergeType: type
+  def MergeType: class
   {
     def x: Int;
   };
 
-  @merge def MergeType: type
+  @merge def MergeType: class
   {
     def xx: Int;
   };
@@ -41,14 +41,14 @@ def Main: module
     def y: Int;
   };
 
-  type WrongType2;
-  type MyType2 {
+  class WrongType2;
+  class MyType2 {
     def x: Int;
   };
-  type MergeType2 {
+  class MergeType2 {
     def y: Int;
   };
-  @merge type MergeType2 {
+  @merge class MergeType2 {
     def z: Int;
   };
 };

--- a/Sources/Tests/Spp/Parsing/user_types_test.alusus.output
+++ b/Sources/Tests/Spp/Parsing/user_types_test.alusus.output
@@ -1,6 +1,6 @@
-ERROR CP1001 @ (15,22): Parser syntax error.
+ERROR CP1001 @ (15,23): Parser syntax error.
 ERROR CD1004 @ (35,25): Incompatible 'def' merge.
-ERROR CP1001 @ (44,18): Parser syntax error.
+ERROR CP1001 @ (44,19): Parser syntax error.
 ------------------ Parsed Data Dump ------------------
 Module [Main.ModuleStatements.StmtList]
  Definition [Main.Def] EmptyType: UserType [Main.Type]

--- a/Sources/Tests/Spp/Running/arrays_test.alusus
+++ b/Sources/Tests/Spp/Running/arrays_test.alusus
@@ -4,13 +4,13 @@ def Main: module
 {
   def print: @expname[printf] function (fmt: ptr[Word[8]], args: ...any)=>Int[64];
 
-  def T1: type
+  def T1: class
   {
     def x: Int[32];
     def y: Int[32];
   };
 
-  def TA1: type
+  def TA1: class
   {
     def i: Int[32];
     def ai: array[Int[32], 4];

--- a/Sources/Tests/Spp/Running/auto_pass_by_ref_test.alusus
+++ b/Sources/Tests/Spp/Running/auto_pass_by_ref_test.alusus
@@ -1,11 +1,11 @@
 import "Srl/Console.alusus";
 
-type Point1 {
+class Point1 {
   def x: Int;
   def y: Int;
 };
 
-type Point2 {
+class Point2 {
   def x: Int;
   def y: Int;
   handler this~init() {};

--- a/Sources/Tests/Spp/Running/circular_referencing_test.alusus
+++ b/Sources/Tests/Spp/Running/circular_referencing_test.alusus
@@ -2,12 +2,12 @@ import "Srl/Console";
 import "Srl/Array";
 use Srl;
 
-type A {
+class A {
     def b: ref[B];
     def i: Int;
 }
 
-type B {
+class B {
     def a: ref[A];
     def i: Int;
 }

--- a/Sources/Tests/Spp/Running/cmd_pack_test.alusus
+++ b/Sources/Tests/Spp/Running/cmd_pack_test.alusus
@@ -1,7 +1,7 @@
 import "Srl/Console.alusus";
 use Srl;
 
-type A {
+class A {
     def i: Int;
     handler this(): Int return this.i;
 }

--- a/Sources/Tests/Spp/Running/custom_init_test.alusus
+++ b/Sources/Tests/Spp/Running/custom_init_test.alusus
@@ -1,6 +1,6 @@
 import "Srl/Console.alusus";
 
-type A
+class A
 {
   def i: Int;
 
@@ -26,13 +26,13 @@ type A
   };
 };
 
-type B
+class B
 {
   def a: A;
   def a2: A;
 };
 
-type C
+class C
 {
   def i: Int;
   def j: Int(17);
@@ -40,7 +40,7 @@ type C
   i = 3;
 };
 
-type D
+class D
 {
     def a: A;
     Srl.Console.print("D constructed!\n");

--- a/Sources/Tests/Spp/Running/eval_statement_test.alusus
+++ b/Sources/Tests/Spp/Running/eval_statement_test.alusus
@@ -78,7 +78,7 @@ testAstInsertion();
 
 Srl.Console.print("\n");
 
-type A {
+class A {
     def i: Int;
     handler this~init() {
         this.i = 1;

--- a/Sources/Tests/Spp/Running/function_pointers_test.alusus
+++ b/Sources/Tests/Spp/Running/function_pointers_test.alusus
@@ -26,7 +26,7 @@ def Main: module
     print("%d\n", getFunc2()(3));
   };
 
-  def Record: type
+  def Record: class
   {
     def pget: ptr[function ()=>Int[32]];
     def pmul: ptr[function (n: Int[32])=>Int[32]];

--- a/Sources/Tests/Spp/Running/if_statement_test.alusus
+++ b/Sources/Tests/Spp/Running/if_statement_test.alusus
@@ -35,7 +35,7 @@ def Main: module
     else { print("else-block") };
   };
 
-  type A
+  class A
   {
     def i: Int;
     handler this~terminate() {

--- a/Sources/Tests/Spp/Running/init_tilde_test.alusus
+++ b/Sources/Tests/Spp/Running/init_tilde_test.alusus
@@ -1,7 +1,7 @@
 import "Srl/Console.alusus";
 import "Srl/Memory.alusus";
 
-type T {
+class T {
   def i: Int;
 
   handler this~init() {

--- a/Sources/Tests/Spp/Running/injection_test.alusus
+++ b/Sources/Tests/Spp/Running/injection_test.alusus
@@ -2,7 +2,7 @@ import "Srl/Console.alusus";
 
 use Srl.Console;
 
-type InnerMost {
+class InnerMost {
   def a: Int;
   handler this.getA():Int { return this.a }
   handler this=Int { this.a = value };
@@ -10,7 +10,7 @@ type InnerMost {
 
 def im: InnerMost;
 
-type Inner {
+class Inner {
   @injection def rim: ref[InnerMost];
   rim~ptr = im~ptr;
 
@@ -21,7 +21,7 @@ type Inner {
   handler this(): Int { return this.i + this.j }
 }
 
-type Outer {
+class Outer {
   @injection def inner: Inner;
   def k: Int;
   a = 6;
@@ -46,7 +46,7 @@ print(
   getO().getA(), getO().getI(), getO().j, getO().k, getO()()
 );
 
-type Wrong {
+class Wrong {
   def i: Int;
   @shared @injection def o: Outer;
   @injection func test {}

--- a/Sources/Tests/Spp/Running/macros_test.alusus
+++ b/Sources/Tests/Spp/Running/macros_test.alusus
@@ -19,7 +19,7 @@ def loop: macro[counter, start, end, action] {
   for counter = start, counter <= end, ++counter action;
 };
 def defType: macro[name, var1, var2, Type] {
-  def name: type {
+  def name: class {
     def var1: Type;
     def var2: Type;
   };

--- a/Sources/Tests/Spp/Running/member_functions_test.alusus
+++ b/Sources/Tests/Spp/Running/member_functions_test.alusus
@@ -2,7 +2,7 @@ import "alusus_spp";
 
 @expname[printf] func print(format: ptr[Word[8]], args: ...any): Int[32];
 
-type A
+class A
 {
   def i: Int;
 
@@ -15,7 +15,7 @@ type A
   };
 };
 
-type B
+class B
 {
   def a: A;
   def f: ptr[@member function];

--- a/Sources/Tests/Spp/Running/nested_block.alusus
+++ b/Sources/Tests/Spp/Running/nested_block.alusus
@@ -1,7 +1,7 @@
 import "alusus_spp";
 def print: @expname[printf] function (fmt: ptr[Word[8]], args: ...any)=>Int[64];
 
-type A {
+class A {
     def i: Int;
     handler this~init(n: Int) {
         this.i = n;

--- a/Sources/Tests/Spp/Running/parameterized_ctors_test.alusus
+++ b/Sources/Tests/Spp/Running/parameterized_ctors_test.alusus
@@ -1,6 +1,6 @@
 import "Srl/Console.alusus";
 
-type A {
+class A {
     def i: Int;
     handler this~init(n: Int) {
         this.i = n;
@@ -30,7 +30,7 @@ func test {
 
 test();
 
-type B {
+class B {
     def a: A(4, 5, 6, 7, 8);
 }
 

--- a/Sources/Tests/Spp/Running/pointer_arithmetic_test.alusus
+++ b/Sources/Tests/Spp/Running/pointer_arithmetic_test.alusus
@@ -14,7 +14,7 @@ for i = 0, i < 6, ++i {
     Console.print("%c\n", (p2-i)~cnt);
 }
 
-type A {
+class A {
     def c: Char;
     def i: Int;
 }

--- a/Sources/Tests/Spp/Running/pointer_member_functions_test.alusus
+++ b/Sources/Tests/Spp/Running/pointer_member_functions_test.alusus
@@ -1,11 +1,11 @@
 import "Srl/Console";
 use Srl;
 
-type N_vtable {
+class N_vtable {
     def printIt: ptr[@member func(this: ref[N])];
 }
 
-type N {
+class N {
     @shared def vtable: N_vtable;
     @no_bind @injection def vtableRef: ref[N_vtable];
     vtableRef~no_deref = vtable;
@@ -16,7 +16,7 @@ type N {
     vtableRef.printIt = printItImpl~ptr;
 }
 
-type N2 {
+class N2 {
     @shared def vtable: N_vtable;
     @injection def super: N;
     vtableRef~no_deref = vtable;
@@ -42,7 +42,7 @@ rn.printIt();
 
 Console.print("\n");
 
-type M {
+class M {
     def i: Int;
 
     func printItImpl (this: ref[M]) {

--- a/Sources/Tests/Spp/Running/references_test.alusus
+++ b/Sources/Tests/Spp/Running/references_test.alusus
@@ -136,7 +136,7 @@ printNum(rri);
 // ~deref & ~no_deref
 //
 
-type A {
+class A {
     def i: Int;
     handler this~init() {
         this.i = 7;
@@ -191,7 +191,7 @@ function receiveTempIntRef (r: temp_ref[Int]) {
 }
 receiveTempIntRef(5i32);
 
-type B {
+class B {
     def i: Int;
     handler this=temp_ref[Int] this.i = value;
 };

--- a/Sources/Tests/Spp/Running/root_scope_test.alusus
+++ b/Sources/Tests/Spp/Running/root_scope_test.alusus
@@ -1,11 +1,11 @@
 import "alusus_spp";
 module Core {
     module Basic {
-        type TiObject {}
+        class TiObject {}
     }
 }
 module Spp {
-    type BuildMgr {
+    class BuildMgr {
         @expname[Spp_BuildMgr_dumpLlvmIrForElement]
         handler this.dumpLlvmIrForElement (element: ptr);
     };

--- a/Sources/Tests/Spp/Running/shared_defs_test.alusus
+++ b/Sources/Tests/Spp/Running/shared_defs_test.alusus
@@ -9,7 +9,7 @@ def Main: module
 {
   def print: alias Std.printf;
 
-  def MyType: type
+  def MyType: class
   {
     def x: Int;
     @shared def y: Int;

--- a/Sources/Tests/Spp/Running/temp_objs_test.alusus
+++ b/Sources/Tests/Spp/Running/temp_objs_test.alusus
@@ -2,7 +2,7 @@ import "Srl/Console";
 import "Srl/String";
 use Srl;
 
-type A {
+class A {
     def i: Int;
     handler this~init() {
         this.i = 7;
@@ -14,7 +14,7 @@ type A {
     }
 }
 
-type Tpl [T: type] {
+class Tpl [T: type] {
     def i: T;
     handler this~init(n: T) {
         this.i = n;
@@ -27,7 +27,7 @@ type Tpl [T: type] {
 }
 
 module M {
-    type B {
+    class B {
         def i: Int;
         handler this~init() {
             this.i = 8;
@@ -40,7 +40,7 @@ module M {
     }
 }
 
-type C {
+class C {
     def i: Int;
     handler this~init(n: Int) {
         this.i = n;
@@ -58,7 +58,7 @@ type C {
     }
 }
 
-type D {
+class D {
     def a: A;
 }
 
@@ -66,7 +66,7 @@ func varArgFunc(count: Int, args: ...Int) {
     Console.print("varArgFunc\n");
 }
 
-type E {
+class E {
     def i: Int = A().i;
     def j: C({ A().i, A().i, 5 });
     varArgFunc({ A().i, A().i, A().i });

--- a/Sources/Tests/Spp/Running/template_type_test.alusus
+++ b/Sources/Tests/Spp/Running/template_type_test.alusus
@@ -2,7 +2,7 @@ import "Core/Basic";
 
 @expname[printf] function printf (s: ptr[Word[8]], ...any) => Int;
 
-type MyType [T: type, f: function, i: integer, s: string = "default string\n"]
+class MyType [T: type, f: function, i: integer, s: string = "default string\n"]
 {
   def v: T;
 
@@ -44,7 +44,7 @@ o3.print();
 def o4: MyType[Int, printOne, 0];
 o4.print();
 
-type MyOtherType [a: ast] {
+class MyOtherType [a: ast] {
     preprocess {
         printf("MyOtherType: %s\n", a~ast.getMyTypeInfo().typeName.buf);
     }

--- a/Sources/Tests/Spp/Running/terminate_tilde_test.alusus
+++ b/Sources/Tests/Spp/Running/terminate_tilde_test.alusus
@@ -1,7 +1,7 @@
 import "Srl/Console.alusus";
 import "Srl/Memory.alusus";
 
-type T {
+class T {
   def i: Int;
 
   handler this~init() {};

--- a/Sources/Tests/Spp/Running/type_merging_test.alusus
+++ b/Sources/Tests/Spp/Running/type_merging_test.alusus
@@ -2,7 +2,7 @@ import "alusus_spp";
 
 def printf: @expname[printf] function (fmt: ptr[Word[8]], args: ...any)=>Int[64];
 
-type A [T: type] {
+class A [T: type] {
     def i: T;
 
     @member func print (this: ref[this_type]) {
@@ -13,25 +13,25 @@ type A [T: type] {
 def AInt: alias A[Int];
 def AFloat: alias A[Float];
 
-@merge type AInt {
+@merge class AInt {
     @member func printValue (this: ref[this_type]) {
         printf("Int %d\n", this.i);
     }
 }
 
-@merge type AFloat {
+@merge class AFloat {
     @member func printValue (this: ref[this_type]) {
         printf("Float %f\n", this.i~cast[Float[64]]);
     }
 }
 
-@merge type A {
+@merge class A {
     @member func sayHello (this: ref[this_type]) {
         printf("hello\n");
     }
 }
 
-@merge type A {
+@merge class A {
     @member func broken (this: ref[this_type]) {
         printf(5);
     }
@@ -59,18 +59,18 @@ func testErrors {
 
 testErrors();
 
-@merge type MissingType {
+@merge class MissingType {
 }
 @merge module Mod {
-    type Alpha {
+    class Alpha {
     }
 }
 @merge module Mod {
-    @merge type Alpha {
+    @merge class Alpha {
     }
 }
 @merge module Mod {
-    @merge type Beta {
+    @merge class Beta {
     }
 }
 testErrors();

--- a/Sources/Tests/Spp/Running/type_ops_test.alusus
+++ b/Sources/Tests/Spp/Running/type_ops_test.alusus
@@ -1,12 +1,12 @@
 import "Srl/Console.alusus";
 use Srl.Console;
 
-type A {
+class A {
     def k: Int;
     handler this(): Int return this.k;
 }
 
-type T {
+class T {
     def i: Int(0);
     def j: Int(0);
     def a: A;
@@ -225,7 +225,7 @@ print("%d\n", t.prop8);
 t.prop9 += 8;
 print("%d\n", t.prop9);
 
-type Parent {
+class Parent {
     handler this.f1(): ptr[Char] as_ptr {
         return "";
     }
@@ -249,7 +249,7 @@ type Parent {
     }
 }
 
-type Child1 {
+class Child1 {
     @injection def parent: Parent;
     def i: Int;
     handler (this: Parent).f1(): ptr[Char] set_ptr {
@@ -261,7 +261,7 @@ type Child1 {
     }
 }
 
-type Child2 {
+class Child2 {
     @injection def parent: Parent;
     def j: Int;
     handler (this: Parent).f1(): ptr[Char] set_ptr {
@@ -294,7 +294,7 @@ test();
 
 // Test error cases
 
-type Other {
+class Other {
   def j: Int;
 };
 

--- a/Sources/Tests/Spp/Running/type_parens_test.alusus
+++ b/Sources/Tests/Spp/Running/type_parens_test.alusus
@@ -1,7 +1,7 @@
 import "Srl/Console";
 use Srl;
 
-type A {
+class A {
     def i: Int;
 
     handler this~init() {
@@ -21,7 +21,7 @@ type A {
     }
 }
 
-type B {
+class B {
     def i: Int;
 
     handler this~init(n: Int) {
@@ -40,7 +40,7 @@ type B {
     }
 }
 
-type C {
+class C {
     def i: Int;
 
     handler this~init(n: Int) {
@@ -60,7 +60,7 @@ type C {
     }
 }
 
-type D {
+class D {
     def i: Int;
 
     handler this_type(n: Int): ref[D] {

--- a/Sources/Tests/Spp/Running/use_statement_test.alusus
+++ b/Sources/Tests/Spp/Running/use_statement_test.alusus
@@ -14,7 +14,7 @@ def Std: module
 };
 
 def TypeContainer: module {
-  type InnerType {
+  class InnerType {
     def j: Int;
   }
 }
@@ -28,7 +28,7 @@ def Other1: module
     Std.printf("Use ");
   }
 
-  type Tp1 {
+  class Tp1 {
     def i: Int;
   }
 

--- a/Sources/Tests/Spp/Running/user_types_test.alusus
+++ b/Sources/Tests/Spp/Running/user_types_test.alusus
@@ -19,7 +19,7 @@ def Main: module
     return i;
   };
 
-  def MyPoint: type
+  def MyPoint: class
   {
     def x: Int[32];
     def y: Int[32];
@@ -31,7 +31,7 @@ def Main: module
 
   def gpoint: MyPoint;
 
-  def MyNested: type
+  def MyNested: class
   {
     def p: MyPoint;
     def i: Int[8];

--- a/Sources/Tests/Spp/Running/variadic_functions_test.alusus
+++ b/Sources/Tests/Spp/Running/variadic_functions_test.alusus
@@ -18,7 +18,7 @@ func sum (count: Int, args: ...Int): Int {
     return r;
 }
 
-type A {
+class A {
     def i: Int;
     handler this~init() { this.i = 7 };
     handler this~init(n: Int) { this.i = n };

--- a/Sources/Tests/Srt/Srl/array_test.alusus
+++ b/Sources/Tests/Srt/Srl/array_test.alusus
@@ -35,7 +35,7 @@ test();
 
 def r: Array[ref[A]];
 
-type A {
+class A {
     def i: ref[Int];
     handler this~init() {
         r.add(this);
@@ -52,7 +52,7 @@ func test2 {
 }
 test2();
 
-type B {
+class B {
     def i: ref[Int];
     handler this~init() {
         Console.print("B~init\n");

--- a/Sources/Tests/Srt/Srl/cpp_interop_test.alusus
+++ b/Sources/Tests/Srt/Srl/cpp_interop_test.alusus
@@ -6,7 +6,7 @@ import "Srl/Map";
 import "cpp_interop_test";
 use Srl;
 
-type Test {
+class Test {
     def i: Int;
     handler this~init() {
         Console.print("Test~init() from Alusus\n");

--- a/Sources/Tests/Srt/Srl/smart_refs_test.alusus
+++ b/Sources/Tests/Srt/Srl/smart_refs_test.alusus
@@ -2,7 +2,7 @@ import "Srl/refs.alusus";
 import "Srl/Console.alusus";
 use Srl;
 
-type Num {
+class Num {
     def x: Int;
     handler this~terminate() {
         Console.print("Num %d is terminated.\n", this.x);

--- a/Sources/Tests/Srt/ast_querying_test.alusus
+++ b/Sources/Tests/Srt/ast_querying_test.alusus
@@ -63,7 +63,7 @@ function dumpElementModifierParams2(element: ref[Core.Basic.TiObject], modName: 
     dumpModifierParams(modifier);
 }
 
-type A {
+class A {
     @modA @modB["abc", "def"] @modC["ijk", "lmn"]
     def i: Int;
 

--- a/Sources/Tests/Srt/closure_test.alusus
+++ b/Sources/Tests/Srt/closure_test.alusus
@@ -86,7 +86,7 @@ testArgRet();
 // Input and ret types with dot
 
 module M {
-    type T {
+    class T {
         def i: Int;
     }
 }
@@ -182,7 +182,7 @@ testSharedAccess();
 
 // Releasing data
 
-type MyType {
+class MyType {
     def i: Int;
     handler this~terminate() {
         print("MyType~terminate %d\n", this.i);

--- a/Tools/Gtk_Syntax_Highlighting/alusus.lang
+++ b/Tools/Gtk_Syntax_Highlighting/alusus.lang
@@ -80,7 +80,7 @@
       <keyword>module</keyword>
       <keyword>function</keyword>
       <keyword>func</keyword>
-      <keyword>type</keyword>
+      <keyword>class</keyword>
       <keyword>macro</keyword>
       <keyword>handler</keyword>
       <keyword>closure</keyword>
@@ -110,6 +110,7 @@
       <keyword>use</keyword>
       <keyword>this</keyword>
       <keyword>this_type</keyword>
+      <keyword>type</keyword>
       <keyword>value</keyword>
       <keyword>init</keyword>
       <keyword>preprocess</keyword>


### PR DESCRIPTION
Use `class` keyword to define new user types instead of the `type` keyword.