### PR TITLE
Fix bug of closures inside templates.

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -68,7 +68,8 @@
             },
             "compilerPath": "/usr/bin/gcc",
             "cStandard": "c11",
-            "cppStandard": "c++17"
+            "cppStandard": "c++17",
+            "configurationProvider": "ms-vscode.cmake-tools"
         },
         {
             "name": "Win32",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -89,5 +89,6 @@
   "cmake.configureOnOpen": false,
   "[alusus]": {
     "editor.tabSize": 4
-  }
+  },
+  "cmake.sourceDirectory": "${workspaceFolder}/Sources"
 }

--- a/Sources/Core/Basic/Box.h
+++ b/Sources/Core/Basic/Box.h
@@ -21,7 +21,9 @@ template<class CTYPE, class PTYPE=TiObject> class Box : public PTYPE
   //============================================================================
   // Type Info
 
+  typedef Box<CTYPE, PTYPE> _MyType;
   TEMPLATE_TYPE_INFO(Box, PTYPE, "Core.Basic", "Core", "alusus.org", (CTYPE, PTYPE));
+  OBJECT_FACTORY(_MyType);
 
 
   //============================================================================

--- a/Sources/Spp/Ast/Helper.h
+++ b/Sources/Spp/Ast/Helper.h
@@ -126,6 +126,9 @@ class Helper : public TiObject, public DynamicBinding, public DynamicInterfacing
   public: METHOD_BINDING_CACHE(isAstReference, Bool, (TiObject*));
   private: static Bool _isAstReference(TiObject *self, TiObject *obj);
 
+  public: METHOD_BINDING_CACHE(isVariable, Bool, (TiObject*));
+  private: static Bool _isVariable(TiObject *self, TiObject *obj);
+
   public: METHOD_BINDING_CACHE(lookupCustomCaster,
     TypeMatchStatus, (
       Type* /* srcType */, Type* /* targetType */, ExecutionContext const* /* ec */, Function *& /* caster */

--- a/Sources/Spp/Ast/UserType.cpp
+++ b/Sources/Spp/Ast/UserType.cpp
@@ -29,7 +29,7 @@ TypeMatchStatus UserType::matchTargetType(
         auto def = ti_cast<Core::Data::Ast::Definition>(body->getElement(i));
         if (def != 0 && !helper->isSharedDef(def)) {
           auto obj = def->getTarget().get();
-          if (obj != 0 && helper->isAstReference(obj)) {
+          if (obj != 0 && helper->isVariable(obj)) {
             auto memberType = helper->traceType(obj);
             auto memberMatchStatus = memberType->matchTargetType(type, helper, ec, opts | TypeMatchOptions::SKIP_DEREF);
             if (
@@ -81,7 +81,7 @@ TypeInitMethod UserType::getInitializationMethod(Helper *helper, ExecutionContex
               method |= TypeInitMethod::USER;
               if (method == TypeInitMethod::BOTH) break;
             }
-          } else if (helper->isAstReference(def->getTarget().get()) && !helper->isSharedDef(def)) {
+          } else if (helper->isVariable(def->getTarget().get()) && !helper->isSharedDef(def)) {
             auto paramPass = ti_cast<Core::Data::Ast::ParamPass>(def->getTarget().get());
             if (paramPass != 0 && paramPass->getType() == Core::Data::Ast::BracketType::ROUND) {
               // If there are args passed to the definition then it's an AUTO init method even if the object type
@@ -123,7 +123,7 @@ TypeInitMethod UserType::getDestructionMethod(Helper *helper, ExecutionContext c
               method |= TypeInitMethod::USER;
               if (method == TypeInitMethod::BOTH) break;
             }
-          } else if (helper->isAstReference(def->getTarget().get()) && !helper->isSharedDef(def)) {
+          } else if (helper->isVariable(def->getTarget().get()) && !helper->isSharedDef(def)) {
             auto type = helper->traceType(def->getTarget().get());
             if (type != 0 && type->getDestructionMethod(helper, ec) != TypeInitMethod::NONE) {
               method |= TypeInitMethod::AUTO;

--- a/Sources/Spp/Ast/Variable.h
+++ b/Sources/Spp/Ast/Variable.h
@@ -1,0 +1,105 @@
+/**
+ * @file Spp/Ast/Variable.h
+ * Contains the header of class Spp::Ast::Variable.
+ *
+ * @copyright Copyright (C) 2021 Sarmad Khalid Abdullah
+ *
+ * @license This file is released under Alusus Public License, Version 1.0.
+ * For details on usage and copying conditions read the full license in the
+ * accompanying license file or at <https://alusus.org/license.html>.
+ */
+//==============================================================================
+
+#ifndef SPP_AST_VARIABLE_H
+#define SPP_AST_VARIABLE_H
+
+namespace Spp::Ast
+{
+
+class Variable : public Core::Data::Node,
+                 public Binding, public MapContaining<TiObject>,
+                 public Core::Data::Ast::MetaHaving, public Core::Data::Printable
+{
+  //============================================================================
+  // Type Info
+
+  TYPE_INFO(Variable, Core::Data::Node, "Spp.Ast", "Spp", "alusus.org");
+  IMPLEMENT_INTERFACES(
+    Core::Data::Node, Binding, MapContaining<TiObject>,
+    Core::Data::Ast::MetaHaving, Core::Data::Printable
+  );
+  OBJECT_FACTORY(Variable);
+
+
+  //============================================================================
+  // Member Variables
+
+  private: TioSharedPtr typeRef;
+  private: Type *type = 0;
+
+
+  //============================================================================
+  // Implementations
+
+  IMPLEMENT_METAHAVING(Variable);
+
+  IMPLEMENT_BINDING(Binding,
+    (prodId, TiWord, VALUE, setProdId(value), &prodId),
+    (sourceLocation, Core::Data::SourceLocation, SHARED_REF, setSourceLocation(value), sourceLocation.get())
+  );
+
+  IMPLEMENT_MAP_CONTAINING(MapContaining<TiObject>,
+    (typeRef, TiObject, SHARED_REF, setTypeRef(value), typeRef.get()),
+    (type, Type, PLAIN_REF, setType(value), type)
+  );
+
+  IMPLEMENT_AST_MAP_PRINTABLE(Variable);
+
+
+  //============================================================================
+  // Constructors & Destructor
+
+  IMPLEMENT_EMPTY_CONSTRUCTOR(Variable);
+
+  IMPLEMENT_ATTR_CONSTRUCTOR(Variable);
+
+  IMPLEMENT_ATTR_MAP_CONSTRUCTOR(Variable);
+
+  public: virtual ~Variable()
+  {
+    DISOWN_SHAREDPTR(this->typeRef);
+  }
+
+
+  //============================================================================
+  // Member Functions
+
+  public: void setTypeRef(TioSharedPtr const &r)
+  {
+    UPDATE_OWNED_SHAREDPTR(this->typeRef, r);
+  }
+  private: void setTypeRef(TiObject *r)
+  {
+    this->setTypeRef(getSharedPtr(r));
+  }
+
+  public: TioSharedPtr const& getTypeRef() const
+  {
+    return this->typeRef;
+  }
+
+  public: void setType(Type *t)
+  {
+    this->type = t;
+  }
+
+  public: Type* getType() const
+  {
+    return this->type;
+  }
+
+}; // class
+
+} // namespace
+
+#endif

--- a/Sources/Spp/Ast/ast.h
+++ b/Sources/Spp/Ast/ast.h
@@ -129,11 +129,12 @@ Function* getDummyBuiltInOpFunction();
 #include "UserType.h"
 #include "FunctionType.h"
 #include "Macro.h"
-// Containers
+// Containers / Definitions
 #include "Module.h"
 #include "TemplateVarDef.h"
 #include "Template.h"
 #include "Function.h"
+#include "Variable.h"
 // Control Statements
 #include "ForStatement.h"
 #include "IfStatement.h"

--- a/Sources/Spp/CodeGen/AstProcessor.cpp
+++ b/Sources/Spp/CodeGen/AstProcessor.cpp
@@ -305,21 +305,18 @@ Bool AstProcessor::_processMacro(
 
   // Replace macro reference with the clone.
   if (owner->isDerivedFrom<Core::Data::Ast::Scope>()) {
+    auto ownerScope = static_cast<Core::Data::Ast::Scope*>(owner);
+    ownerScope->remove(indexInOwner);
+    Int index = indexInOwner;
     if (macroInstance->isDerivedFrom<Core::Data::Ast::Scope>()) {
       // Merge the two scopes.
-      auto ownerScope = static_cast<Core::Data::Ast::Scope*>(owner);
       auto instanceScope = macroInstance.s_cast_get<Core::Data::Ast::Scope>();
-      ownerScope->remove(indexInOwner);
-      Int index = indexInOwner;
       Core::Data::Ast::addPossiblyMergeableElements(
         instanceScope, ownerScope, index, astProcessor->astHelper->getSeeker(),
         astProcessor->astHelper->getNoticeStore()
       );
     } else {
       // Merge the element into the owner scope.
-      auto ownerScope = static_cast<Core::Data::Ast::Scope*>(owner);
-      ownerScope->remove(indexInOwner);
-      Int index = indexInOwner;
       Core::Data::Ast::addPossiblyMergeableElement(
         macroInstance.get(), ownerScope, index, astProcessor->astHelper->getSeeker(),
         astProcessor->astHelper->getNoticeStore()
@@ -364,9 +361,9 @@ Bool AstProcessor::_insertInterpolatedAst(
   }
   // Insert the interpolated AST.
   if (astProcessor->currentPreprocessOwner->isDerivedFrom<Core::Data::Ast::Scope>()) {
+    auto ownerScope = static_cast<Core::Data::Ast::Scope*>(astProcessor->currentPreprocessOwner);
     if (result->isDerivedFrom<Core::Data::Ast::Scope>()) {
       // Merge the two scopes.
-      auto ownerScope = static_cast<Core::Data::Ast::Scope*>(astProcessor->currentPreprocessOwner);
       auto insertedScope = result.s_cast_get<Core::Data::Ast::Scope>();
       Core::Data::Ast::addPossiblyMergeableElements(
         insertedScope, ownerScope, astProcessor->currentPreprocessInsertionPosition,
@@ -374,7 +371,6 @@ Bool AstProcessor::_insertInterpolatedAst(
       );
     } else {
       // Add a single element to the scope
-      auto ownerScope = static_cast<Core::Data::Ast::Scope*>(astProcessor->currentPreprocessOwner);
       Core::Data::Ast::addPossiblyMergeableElement(
         result.get(), ownerScope, astProcessor->currentPreprocessInsertionPosition,
         astProcessor->astHelper->getSeeker(), astProcessor->astHelper->getNoticeStore()

--- a/Sources/Spp/CodeGen/ExpressionGenerator.cpp
+++ b/Sources/Spp/CodeGen/ExpressionGenerator.cpp
@@ -1679,7 +1679,7 @@ Bool ExpressionGenerator::_generateDerefOp(
   // Dereference and get content type.
   GenResult target;
   if (!expGenerator->dereferenceIfNeeded(
-    static_cast<Ast::Type*>(operandResult.astType), operandResult.targetData.get(), true, true, session, target
+    operandResult.astType, operandResult.targetData.get(), true, true, session, target
   )) return false;
   auto refType = ti_cast<Spp::Ast::ReferenceType>(target.astType);
   if (refType == 0) {
@@ -1713,7 +1713,7 @@ Bool ExpressionGenerator::_generateNoDerefOp(
     // Dereference and get content type.
     GenResult target;
     if (!expGenerator->dereferenceIfNeeded(
-      static_cast<Ast::Type*>(operandResult.astType), operandResult.targetData.get(), false, true, session, target
+      operandResult.astType, operandResult.targetData.get(), false, true, session, target
     )) return false;
     auto refType = ti_cast<Spp::Ast::ReferenceType>(target.astType);
     if (refType == 0) {
@@ -1893,7 +1893,7 @@ Bool ExpressionGenerator::_generateInitOp(
   // Dereference and get content type.
   GenResult target;
   if (!expGenerator->dereferenceIfNeeded(
-    static_cast<Ast::Type*>(operandResult.astType), operandResult.targetData.get(), false, false, session, target
+    operandResult.astType, operandResult.targetData.get(), false, false, session, target
   )) return false;
   auto astRefType = ti_cast<Ast::ReferenceType>(target.astType);
   if (astRefType == 0) {
@@ -1945,7 +1945,7 @@ Bool ExpressionGenerator::_generateTerminateOp(
   // Dereference and get content type.
   GenResult target;
   if (!expGenerator->dereferenceIfNeeded(
-    static_cast<Ast::Type*>(operandResult.astType), operandResult.targetData.get(), false, false, session, target
+    operandResult.astType, operandResult.targetData.get(), false, false, session, target
   )) return false;
   auto astRefType = ti_cast<Ast::ReferenceType>(target.astType);
   if (astRefType == 0) {
@@ -2259,7 +2259,7 @@ Bool ExpressionGenerator::_generateReferenceToNonObjectMember(
 
   Bool retVal = false;
 
-  if (expGenerator->astHelper->isAstReference(obj)) {
+  if (expGenerator->astHelper->isVariable(obj)) {
     // Make sure the var is not an object member.
     if (expGenerator->getAstHelper()->getVariableDomain(obj) == Ast::DefinitionDomain::OBJECT) {
       expGenerator->astHelper->getNoticeStore()->add(newSrdObj<Spp::Notices::InvalidObjectMemberAccessNotice>(

--- a/Sources/Spp/CodeGen/Generator.cpp
+++ b/Sources/Spp/CodeGen/Generator.cpp
@@ -86,7 +86,7 @@ Bool Generator::_generateModule(TiObject *self, Spp::Ast::Module *astModule, Ses
       } else if (target->isDerivedFrom<Spp::Ast::UserType>()) {
         if (!generation->generateUserTypeBody(static_cast<Spp::Ast::UserType*>(target), session)) result = false;
         // TODO: Generate member functions and sub-types.
-      } else if (generator->getAstHelper()->isAstReference(target)) {
+      } else if (generator->getAstHelper()->isVariable(target)) {
         // Generate global variable.
         if (!generation->generateVarDef(def, session)) {
           result = false;
@@ -913,7 +913,7 @@ Bool Generator::_generateStatement(
     //     newSrdObj<Spp::Notices::UnsupportedOperationNotice>(def->findSourceLocation())
     //   );
     //   retVal = false;
-    } else if (generator->getAstHelper()->isAstReference(target)) {
+    } else if (generator->getAstHelper()->isVariable(target)) {
       // Generate local variable.
       retVal = generation->generateVarDef(def, session);
     } else {

--- a/Sources/Spp/CodeGen/TypeGenerator.cpp
+++ b/Sources/Spp/CodeGen/TypeGenerator.cpp
@@ -300,7 +300,7 @@ Bool TypeGenerator::_generateUserTypeMemberVars(
     auto def = ti_cast<Data::Ast::Definition>(body->getElement(i));
     if (def != 0) {
       auto obj = def->getTarget().get();
-      if (typeGenerator->astHelper->isAstReference(obj)) {
+      if (typeGenerator->astHelper->isVariable(obj)) {
         if (typeGenerator->astHelper->getVariableDomain(def) != Ast::DefinitionDomain::GLOBAL) {
           TiObject *tgType;
           Ast::Type *astMemberType;
@@ -411,7 +411,7 @@ Bool TypeGenerator::_generateUserTypeAutoConstructor(
     if (def != 0) {
       auto target = def->getTarget().get();
       if (
-        typeGenerator->getAstHelper()->isAstReference(target) &&
+        typeGenerator->getAstHelper()->isVariable(target) &&
         typeGenerator->getAstHelper()->getVariableDomain(def) == Ast::DefinitionDomain::OBJECT
       ) {
         // Initialize member variable.
@@ -494,7 +494,7 @@ Bool TypeGenerator::_generateUserTypeAutoDestructor(
     if (def != 0) {
       auto target = def->getTarget().get();
       if (
-        typeGenerator->getAstHelper()->isAstReference(target) &&
+        typeGenerator->getAstHelper()->isVariable(target) &&
         typeGenerator->getAstHelper()->getVariableDomain(def) == Ast::DefinitionDomain::OBJECT
       ) {
         // Destruct member variable.
@@ -876,7 +876,7 @@ Bool TypeGenerator::_generateDefaultUserTypeValue(
     auto def = ti_cast<Core::Data::Ast::Definition>(body->getElement(i));
     if (def != 0) {
       auto obj = def->getTarget().get();
-      if (typeGenerator->getAstHelper()->isAstReference(obj)) {
+      if (typeGenerator->getAstHelper()->isVariable(obj)) {
         if (typeGenerator->getAstHelper()->getVariableDomain(def) == Ast::DefinitionDomain::OBJECT) {
           TiObject *tgMemberType;
           Ast::Type *astMemberType;

--- a/Sources/Spp/Rt/AstMgr.cpp
+++ b/Sources/Spp/Rt/AstMgr.cpp
@@ -34,7 +34,9 @@ void AstMgr::initBindingCaches()
     &this->buildAst_shared,
     &this->getCurrentPreprocessOwner,
     &this->getCurrentPreprocessInsertionPosition,
-    &this->getVariableDomain
+    &this->getVariableDomain,
+    &this->traceType,
+    &this->cloneAst
   });
 }
 
@@ -56,6 +58,8 @@ void AstMgr::initBindings()
   this->getCurrentPreprocessOwner = &AstMgr::_getCurrentPreprocessOwner;
   this->getCurrentPreprocessInsertionPosition = &AstMgr::_getCurrentPreprocessInsertionPosition;
   this->getVariableDomain = &AstMgr::_getVariableDomain;
+  this->traceType = &AstMgr::_traceType;
+  this->cloneAst = &AstMgr::_cloneAst;
 }
 
 
@@ -79,6 +83,8 @@ void AstMgr::initializeRuntimePointers(CodeGen::GlobalItemRepo *globalItemRepo, 
     S("Spp_AstMgr_getCurrentPreprocessInsertionPosition"), (void*)&AstMgr::_getCurrentPreprocessInsertionPosition
   );
   globalItemRepo->addItem(S("Spp_AstMgr_getVariableDomain"), (void*)&AstMgr::_getVariableDomain);
+  globalItemRepo->addItem(S("Spp_AstMgr_traceType"), (void*)&AstMgr::_traceType);
+  globalItemRepo->addItem(S("Spp_AstMgr_cloneAst"), (void*)&AstMgr::_cloneAst);
 }
 
 
@@ -277,10 +283,25 @@ Int AstMgr::_getCurrentPreprocessInsertionPosition(TiObject *self)
 }
 
 
-Int AstMgr::_getVariableDomain(TiObject *self, TiObject* ast)
+Int AstMgr::_getVariableDomain(TiObject *self, TiObject *ast)
 {
   PREPARE_SELF(astMgr, AstMgr);
   return astMgr->astHelper->getVariableDomain(ast);
+}
+
+
+Spp::Ast::Type* AstMgr::_traceType(TiObject *self, TiObject *astNode)
+{
+  PREPARE_SELF(astMgr, AstMgr);
+  return astMgr->astHelper->traceType(astNode);
+}
+
+
+SharedPtr<TiObject> AstMgr::_cloneAst(TiObject *self, TiObject *astNodeToCopy, TiObject *astNodeForSourceLocation)
+{
+  PREPARE_SELF(astMgr, AstMgr);
+  auto sourceLocation = Core::Data::Ast::findSourceLocation(astNodeForSourceLocation).get();
+  return Core::Data::Ast::clone(astNodeToCopy, sourceLocation);
 }
 
 } // namespace

--- a/Sources/Spp/Rt/AstMgr.h
+++ b/Sources/Spp/Rt/AstMgr.h
@@ -160,6 +160,12 @@ class AstMgr : public TiObject, public DynamicBinding, public DynamicInterfacing
   public: METHOD_BINDING_CACHE(getVariableDomain, Int, (TiObject*));
   public: static Int _getVariableDomain(TiObject *self, TiObject* ast);
 
+  public: METHOD_BINDING_CACHE(traceType, Spp::Ast::Type*, (TiObject*));
+  public: static Spp::Ast::Type* _traceType(TiObject *self, TiObject *astNode);
+
+  public: METHOD_BINDING_CACHE(cloneAst, SharedPtr<TiObject>, (TiObject*, TiObject*));
+  public: static SharedPtr<TiObject> _cloneAst(TiObject *self, TiObject *nodeToCopy, TiObject *nodeForSourceLocation);
+
   /// @}
 
 }; // class

--- a/Sources/Spp/SeekerExtension.cpp
+++ b/Sources/Spp/SeekerExtension.cpp
@@ -274,7 +274,7 @@ Core::Data::Seeker::Verb SeekerExtension::_foreachByParamPass_template(
 Core::Data::Seeker::Verb SeekerExtension::_foreachByThisTypeRef(
   TiObject *self, TiObject *data, Core::Data::Seeker::ForeachCallback const &cb, Word flags
 ) {
-  auto node = static_cast<Core::Data::Node*>(data);
+  auto node = ti_cast<Core::Data::Node>(data);
   while (node != 0) {
     if (node->isDerivedFrom<Spp::Ast::DataType>()) {
       return cb(Core::Data::Seeker::Action::TARGET_MATCH, node);

--- a/Sources/Srt/Spp.alusus
+++ b/Sources/Srt/Spp.alusus
@@ -107,18 +107,6 @@ import "Srl/refs";
             return result;
         }
 
-        handler this.clone(obj: ref[Core.Basic.TiObject]): Srl.SrdRef[Core.Basic.TiObject] {
-            def result: Srl.SrdRef[Core.Basic.TiObject];
-            if obj~ptr != 0 {
-                this.buildAst(
-                    (ast item),
-                    Srl.Map[Srl.String, ref[Core.Basic.TiObject]]().set(Srl.String("item"), obj),
-                    result
-                );
-            }
-            return result;
-        }
-
         @expname[Spp_AstMgr_getCurrentPreprocessOwner]
         handler this.getCurrentPreprocessOwner(): ref[Core.Basic.TiObject];
 
@@ -127,6 +115,17 @@ import "Srl/refs";
 
         @expname[Spp_AstMgr_getVariableDomain]
         handler this.getVariableDomain(element: ref[Core.Basic.TiObject]) => Int;
+
+        @expname[Spp_AstMgr_traceType]
+        handler this.traceType(element: ref[Core.Basic.TiObject]) => ref[Spp.Ast.Type];
+
+        @expname[Spp_AstMgr_cloneAst]
+        handler this.cloneAst(
+            element: ref[Core.Basic.TiObject], sourceLocationNode: ref[Core.Basic.TiObject]
+        ): Srl.SrdRef[Core.Basic.TiObject];
+        handler this.cloneAst(element: ref[Core.Basic.TiObject]): Srl.SrdRef[Core.Basic.TiObject] {
+            return this.cloneAst(element, nullRef[Core.Basic.TiObject]);
+        }
     };
     def astMgr: ref[AstMgr];
 

--- a/Sources/Srt/Spp/Ast.alusus
+++ b/Sources/Srt/Spp/Ast.alusus
@@ -46,6 +46,7 @@ import "Core/Data";
         defAstType[Function, "alusus.org/Spp/Spp.Ast.Function"];
         defAstType[Macro, "alusus.org/Spp/Spp.Ast.Macro"];
         defAstType[Module, "alusus.org/Spp/Spp.Ast.Module"];
+        defAstType[Variable, "alusus.org/Spp/Spp.Ast.Variable"];
 
         defAstType[IfStatement, "alusus.org/Spp/Spp.Ast.IfStatement"];
         defAstType[WhileStatement, "alusus.org/Spp/Spp.Ast.WhileStatement"];

--- a/Sources/Srt/Srl/refs.h
+++ b/Sources/Srt/Srl/refs.h
@@ -74,6 +74,8 @@ class RefCounter
 // Shared Reference
 template<class T> class SrdRef
 {
+  friend WkRef<T>;
+
   //=================
   // Member Variables
 
@@ -293,6 +295,8 @@ template<class T> class SrdRef
 // Weak Reference
 template<class T> class WkRef
 {
+  friend SrdRef<T>;
+
   //=================
   // Member Variables
 

--- a/Sources/Srt/closure.alusus
+++ b/Sources/Srt/closure.alusus
@@ -36,7 +36,7 @@ module Closures {
     }
 
     func fillClosureBody (rawFnType: ref[TiObject]) {
-        def fnType: TioSrdRef = generateFuncType(rawFnType, nullRef[TiObject], ast ref[Srl.RefCounter]);
+        def fnType: TioSrdRef = generateFuncType(rawFnType, nullRef[TiObject], (ast ref[Srl.RefCounter]), true);
         def argList: TioSrdRef = generateFuncArgListFromType(fnType.obj);
 
         def call: TioSrdRef;
@@ -63,7 +63,7 @@ module Closures {
         );
         MapContainerOf[fn.obj].setElement(
             "type",
-            generateFuncType(rawFnType, (ast ref[this_type]), nullRef[TiObject]).obj
+            generateFuncType(rawFnType, (ast ref[this_type]), nullRef[TiObject], true).obj
         );
 
         Spp.astMgr.insertAst(
@@ -90,8 +90,8 @@ module Closures {
             AstTemplateMap().set(String("statements"), statements)
         );
         // Assign the function type.
-        def closureArgFnType: TioSrdRef = generateFuncType(fnTypeSpec, nullRef[TiObject], nullRef[TiObject]);
-        def fnType: TioSrdRef = generateFuncType(fnTypeSpec, nullRef[TiObject], ast ref[Srl.RefCounter]);
+        def closureArgFnType: TioSrdRef = generateFuncType(fnTypeSpec, nullRef[TiObject], nullRef[TiObject], false);
+        def fnType: TioSrdRef = generateFuncType(fnTypeSpec, nullRef[TiObject], (ast ref[Srl.RefCounter]), false);
         MapContainerOf[fn.obj].setElement("type", fnType.obj);
         // Find external variables of that function.
         def varDefs: AstTemplateMap;
@@ -145,7 +145,9 @@ module Closures {
         );
     }
 
-    func generateFuncType (t: ref[TiObject], thisType: ref[TiObject], payloadType: ref[TiObject]): TioSrdRef {
+    func generateFuncType (
+        t: ref[TiObject], thisType: ref[TiObject], payloadType: ref[TiObject], useBox: Bool
+    ): TioSrdRef {
         def args: ref[TiObject];
         def retVal: ref[TiObject];
         if isDerivedFrom[t, Spp.Ast.FunctionType] or isDerivedFrom[t, Ast.LinkOperator] {
@@ -160,12 +162,12 @@ module Closures {
         def inputs: SrdRef[Ast.Map] = newSrdObj[Ast.Map];
         DynMapContainerOf[inputs.obj].{
             if thisType~ptr != 0 this.addElement("this", thisType);
-            addFuncArgs(args, 0, this);
+            addFuncArgs(args, 0, this, useBox);
             if payloadType~ptr != 0 this.addElement("__payload", payloadType);
         };
         def fnType: TioSrdRef = TioSrdRef().{
-            if thisType~ptr != 0 this = Spp.astMgr.clone(ast @member func)
-            else this = Spp.astMgr.clone(ast func);
+            if thisType~ptr != 0 this = Spp.astMgr.cloneAst(ast @member func)
+            else this = Spp.astMgr.cloneAst(ast func);
         };
         MapContainerOf[fnType.obj].{
             this.setElement("argTypes", inputs.obj);
@@ -174,22 +176,29 @@ module Closures {
         return fnType;
     }
 
-    func addFuncArgs (input: ref[TiObject], index: Int, map: ref[DynamicMapContaining]) {
+    func addFuncArgs (input: ref[TiObject], index: Int, map: ref[DynamicMapContaining], useBox: Bool) {
         if input~ptr == 0 return;
         def inputContaining: ContainerOf[input];
         if isDerivedFrom[input, Ast.Bracket] {
-            addFuncArgs(inputContaining.getElement(0), index, map);
+            addFuncArgs(inputContaining.getElement(0), index, map, useBox);
         } else if isDerivedFrom[input, Ast.Map] {
             getInterface[input, MapContaining].{
                 def i: Word;
                 for i = 0, i < inputContaining.getElementCount(), ++i {
-                    map.addElement(this.getElementKey(i), this.getElement(i));
+                    def inputObj: ref[TiObject](this.getElement(i));
+                    if useBox {
+                        map.addElement(this.getElementKey(i), newSrdObj[Spp.Ast.Variable].{
+                            MapContainerOf[this].setElement("type", Spp.astMgr.traceType(inputObj));
+                        });
+                    } else {
+                        map.addElement(this.getElementKey(i), Spp.astMgr.cloneAst(inputObj));
+                    }
                 }
             };
         } else if isDerivedFrom[input, Ast.List] {
             def i: Word;
             for i = 0, i < inputContaining.getElementCount(), ++i {
-                addFuncArgs(inputContaining.getElement(i), i, map);
+                addFuncArgs(inputContaining.getElement(i), i, map, useBox);
             }
         } else if isDerivedFrom[input, Ast.LinkOperator] and isStringPropEqual(input, "type", ":") {
             dynCastRef[inputContaining.getElement(0), Ast.Identifier].{
@@ -198,10 +207,22 @@ module Closures {
                     Spp.buildMgr.raiseBuildNotice("SPPH1006", 1, input);
                     return;
                 }
-                map.addElement(this.value.value, inputContaining.getElement(1));
+                if useBox {
+                    map.addElement(this.value.value, newSrdObj[Spp.Ast.Variable].{
+                        MapContainerOf[this].setElement("type", Spp.astMgr.traceType(inputContaining.getElement(1)));
+                    });
+                } else {
+                    map.addElement(this.value.value, Spp.astMgr.cloneAst(inputContaining.getElement(1)));
+                }
             };
         } else {
-            map.addElement(String("__") + index, input);
+            if useBox {
+                map.addElement(String("__") + index, newSrdObj[Spp.Ast.Variable].{
+                    MapContainerOf[this].setElement("type", Spp.astMgr.traceType(input));
+                });
+            } else {
+                map.addElement(String("__") + index, Spp.astMgr.cloneAst(input));
+            }
         }
     }
 
@@ -225,7 +246,7 @@ module Closures {
             arg.value.value = String(argsMap.getElementKey(i).buf);
             listContainer.addElement(arg.obj);
         }
-        listContainer.addElement(Spp.astMgr.clone(ast this.data.refCounter).obj);
+        listContainer.addElement(Spp.astMgr.cloneAst(ast this.data.refCounter).obj);
         return castSrdRef[list, TiObject];
     }
 
@@ -311,7 +332,7 @@ preprocess {
             if container.getElementCount() == 2u {
                 // Generate closure type reference.
                 def closureArgFnType: TioSrdRef = generateFuncType(
-                    container.getElement(1), nullRef[TiObject], nullRef[TiObject]
+                    container.getElement(1), nullRef[TiObject], nullRef[TiObject], false
                 );
                 return Spp.astMgr.buildAst(
                     (ast Closures.Closure[t]),

--- a/Sources/Tests/Srt/closure_test.alusus
+++ b/Sources/Tests/Srt/closure_test.alusus
@@ -209,6 +209,22 @@ func testDataRelease {
 }
 testDataRelease();
 
+// Templates
+
+class MyClass  [T: type] {
+    def MyClosure: alias closure (t: T);
+    def c: MyClosure;
+}
+
+func testTemplates {
+    def v: MyClass[Int];
+    v.c = closure (t: Int) {
+        print("testTemplates: %d\n", t);
+    };
+    v.c(7);
+}
+testTemplates();
+
 // Erro cases
 
 func testErrorCases {

--- a/Sources/Tests/Srt/closure_test.alusus.output
+++ b/Sources/Tests/Srt/closure_test.alusus.output
@@ -12,144 +12,145 @@ prepareSharedAccess: 12, 13
 MyType~terminate 14
 prepareDataRelease: 15
 MyType~terminate 15
+testTemplates: 7
 
 testErrorCases:
-ERROR SPPA1003 @ (215,38)
-from (317,26): No valid match was found for the given type.
-ERROR SPPA1003 @ (215,38)
-from (317,26)
-from (317,26)
-from (317,26): No valid match was found for the given type.
-ERROR SPPA1003 @ (215,38)
-from (317,26): No valid match was found for the given type.
-ERROR SPPA1003 @ (215,38)
-from (317,26): No valid match was found for the given type.
-ERROR SPPA1003 @ (215,38)
-from (317,26): No valid match was found for the given type.
-ERROR SPPA1003 @ (215,38)
-from (317,26): No valid match was found for the given type.
-ERROR SPPA1003 @ (215,61)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (215,61)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (215,38)
-from (317,26): No valid match was found for the given type.
-ERROR SPPA1003 @ (215,61)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (215,61)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (215,61)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (215,61)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (215,61)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (215,61)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,37)
-from (317,26): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,37)
-from (317,26): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,37)
-from (317,26): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,37)
-from (317,26): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,37)
-from (317,26): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,37)
-from (317,26): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,37)
-from (317,26): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,37)
-from (317,26)
-from (317,26)
-from (317,26): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,37)
-from (317,26): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,37)
-from (317,26): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,37)
-from (317,26): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,37)
-from (317,26): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,58)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,58)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,58)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,58)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,58)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,58)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,58)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,58)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,37)
-from (317,26): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,58)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,58)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,58)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,58)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,58)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1003 @ (218,58)
-from (323,41)
-from (323,41)
-from (323,41): No valid match was found for the given type.
-ERROR SPPA1007 @ (223,9)
-from (323,41)
+ERROR SPPA1003 @ (231,38)
+from (338,26): No valid match was found for the given type.
+ERROR SPPA1003 @ (231,38)
+from (338,26)
+from (338,26)
+from (338,26): No valid match was found for the given type.
+ERROR SPPA1003 @ (231,38)
+from (338,26): No valid match was found for the given type.
+ERROR SPPA1003 @ (231,38)
+from (338,26): No valid match was found for the given type.
+ERROR SPPA1003 @ (231,38)
+from (338,26): No valid match was found for the given type.
+ERROR SPPA1003 @ (231,38)
+from (338,26): No valid match was found for the given type.
+ERROR SPPA1003 @ (231,61)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (231,61)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (231,38)
+from (338,26): No valid match was found for the given type.
+ERROR SPPA1003 @ (231,61)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (231,61)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (231,61)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (231,61)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (231,61)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (231,61)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,37)
+from (338,26): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,37)
+from (338,26): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,37)
+from (338,26): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,37)
+from (338,26): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,37)
+from (338,26): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,37)
+from (338,26): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,37)
+from (338,26): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,37)
+from (338,26)
+from (338,26)
+from (338,26): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,37)
+from (338,26): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,37)
+from (338,26): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,37)
+from (338,26): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,37)
+from (338,26): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,58)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,58)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,58)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,58)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,58)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,58)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,58)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,58)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,37)
+from (338,26): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,58)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,58)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,58)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,58)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,58)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1003 @ (234,58)
+from (344,41)
+from (344,41)
+from (344,41): No valid match was found for the given type.
+ERROR SPPA1007 @ (239,9)
+from (344,41)
 from (84,18)
-from (323,41)
-from (323,41): Unknown symbol.
-ERROR SPPH1006 @ (229,35): Invalid function arg name.
-ERROR SPPH1006 @ (232,41): Invalid function arg name.
+from (344,41)
+from (344,41): Unknown symbol.
+ERROR SPPH1006 @ (245,35): Invalid function arg name.
+ERROR SPPH1006 @ (248,41): Invalid function arg name.


### PR DESCRIPTION
Fix a bug where closure argument types could not be found when the type is a template argument.
Fixed by introducing Variable AST type which will later be used for other source code clean ups. Closures now use this new AST type to point directly to the type instead of cloning the reference which does not work when the reference is attached to a different scope.