### PR TITLE
Fixes to variadic functions and assignment operation.

### DIFF
--- a/Sources/Spp/Ast/CalleeTracer.cpp
+++ b/Sources/Spp/Ast/CalleeTracer.cpp
@@ -734,7 +734,9 @@ void CalleeTracer::_lookupCallee_builtInOp(TiObject *self, CalleeLookupRequest &
         result.pushObject(getDummyBuiltInOpFunction());
         result.pushThisMarker();
       } else {
-        if (result.notice == 0) result.notice = newSrdObj<Spp::Notices::IncompatibleOperatorTypesNotice>();
+        if (result.notice == 0 || result.notice->isA<Spp::Notices::InvalidOperationNotice>()) {
+          result.notice = newSrdObj<Spp::Notices::IncompatibleOperatorTypesNotice>();
+        }
         return;
       }
     } else {

--- a/Sources/Spp/Ast/FunctionType.cpp
+++ b/Sources/Spp/Ast/FunctionType.cpp
@@ -50,7 +50,11 @@ TypeMatchStatus FunctionType::matchTargetType(
       if ((thisArgPack == 0 && argPack != 0) || (thisArgPack != 0 && argPack == 0)) return TypeMatchStatus::NONE;
       else if (argPack != 0) {
         // Check arg packs.
-        if (thisArgPack->getMin() <= argPack->getMin() || thisArgPack->getMax() >= argPack->getMax()) {
+        if (thisArgPack->getMin() > argPack->getMin()) {
+          return TypeMatchStatus::NONE;
+        } else if (thisArgPack->getMax() != 0 && argPack->getMax() != 0 && thisArgPack->getMax() < argPack->getMax()) {
+          return TypeMatchStatus::NONE;
+        } else if (thisArgPack->getMax() != 0 && argPack->getMax() == 0) {
           return TypeMatchStatus::NONE;
         } else if (thisArgPack->getMin() != argPack->getMin() || thisArgPack->getMax() != argPack->getMax()) {
           result = TypeMatchStatus::IMPLICIT_CAST;

--- a/Sources/Tests/Spp/Building/temp_objs_test.alusus.output
+++ b/Sources/Tests/Spp/Building/temp_objs_test.alusus.output
@@ -77,33 +77,32 @@ define void @"test()"() {
   %16 = getelementptr %E, %E* %e, i32 0, i32 0
   %17 = getelementptr %E, %E* %e, i32 0, i32 1
   %18 = load i32, i32* %16
-  %19 = load %C, %C* %17
-  %20 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([8 x i8], [8 x i8]* @"#anonymous9", i32 0, i32 0), i32 %18, %C %19)
+  %19 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([8 x i8], [8 x i8]* @"#anonymous9", i32 0, i32 0), i32 %18, %C* %17)
   %c = alloca %C
   %"#temp11" = alloca %A
   call void @"A.~init(iref[A])"(%A* %"#temp11")
-  %21 = getelementptr %A, %A* %"#temp11", i32 0, i32 0
+  %20 = getelementptr %A, %A* %"#temp11", i32 0, i32 0
   %"#temp12" = alloca %A
   call void @"A.~init(iref[A])"(%A* %"#temp12")
-  %22 = getelementptr %A, %A* %"#temp12", i32 0, i32 0
+  %21 = getelementptr %A, %A* %"#temp12", i32 0, i32 0
+  %22 = load i32, i32* %20
   %23 = load i32, i32* %21
-  %24 = load i32, i32* %22
-  call void (%C*, i32, ...) @"C.~init(iref[C],Int[32],ArgPack[Int[32],1,0])"(%C* %c, i32 2, i32 %23, i32 %24)
+  call void (%C*, i32, ...) @"C.~init(iref[C],Int[32],ArgPack[Int[32],1,0])"(%C* %c, i32 2, i32 %22, i32 %23)
   call void @"A.~terminate(iref[A])"(%A* %"#temp11")
   call void @"A.~terminate(iref[A])"(%A* %"#temp12")
   %"#temp13" = alloca %A
   call void @"A.~init(iref[A])"(%A* %"#temp13")
-  %25 = getelementptr %A, %A* %"#temp13", i32 0, i32 0
+  %24 = getelementptr %A, %A* %"#temp13", i32 0, i32 0
   %"#temp14" = alloca %A
   call void @"A.~init(iref[A])"(%A* %"#temp14")
-  %26 = getelementptr %A, %A* %"#temp14", i32 0, i32 0
+  %25 = getelementptr %A, %A* %"#temp14", i32 0, i32 0
+  %26 = load i32, i32* %24
   %27 = load i32, i32* %25
-  %28 = load i32, i32* %26
-  call void (i32, ...) @"varArgFunc(Int[32],ArgPack[Int[32],0,0])"(i32 2, i32 %27, i32 %28)
+  call void (i32, ...) @"varArgFunc(Int[32],ArgPack[Int[32],0,0])"(i32 2, i32 %26, i32 %27)
   call void @"A.~terminate(iref[A])"(%A* %"#temp13")
   call void @"A.~terminate(iref[A])"(%A* %"#temp14")
-  %29 = load i32, i32* getelementptr inbounds (%C, %C* @"!globalC", i32 0, i32 0)
-  %30 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"#anonymous10", i32 0, i32 0), i32 %29)
+  %28 = load i32, i32* getelementptr inbounds (%C, %C* @"!globalC", i32 0, i32 0)
+  %29 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"#anonymous10", i32 0, i32 0), i32 %28)
   call void @E.__autoDestruct__(%E* %e)
   call void @"C.~terminate(iref[C])"(%C* %c)
   ret void

--- a/Sources/Tests/Spp/Building/variadic_functions_test.alusus
+++ b/Sources/Tests/Spp/Building/variadic_functions_test.alusus
@@ -16,6 +16,9 @@ def Main: module
 
     f5({ 1, 2.3, -3, 7, 9 });
 
+    def mt: Mt;
+    f6({ mt });
+
     // errors:
     f1("hello");
     f2("hello");
@@ -57,6 +60,16 @@ def Main: module
   {
       while --count > 0 if args~next_arg[Int] > 0 return count;
       return count;
+  }
+
+  def f6: function (count: Int, args: ...any) {
+    def mt: Mt = args~next_arg[Mt];
+  }
+
+  class Mt {
+    def i: Int;
+    handler this~init() {}
+    handler this = (r: ref[Mt]) { this.i = r.i }
   }
 };
 

--- a/Sources/Tests/Spp/Building/variadic_functions_test.alusus.output
+++ b/Sources/Tests/Spp/Building/variadic_functions_test.alusus.output
@@ -1,10 +1,10 @@
-ERROR SPPA1005 @ (20,5): Multiple matches were found for the given callee.
-ERROR SPPA1008 @ (21,5): Provided arguments do not match signature.
-ERROR SPPA1008 @ (22,5): Provided arguments do not match signature.
-ERROR SPPA1008 @ (23,5): Provided arguments do not match signature.
-ERROR SPPA1007 @ (24,5): Unknown symbol.
+ERROR SPPA1005 @ (23,5): Multiple matches were found for the given callee.
+ERROR SPPA1008 @ (24,5): Provided arguments do not match signature.
+ERROR SPPA1008 @ (25,5): Provided arguments do not match signature.
+ERROR SPPA1008 @ (26,5): Provided arguments do not match signature.
+ERROR SPPA1007 @ (27,5): Unknown symbol.
 ERROR SPPG1022 @ (5,13): Missing a return statement for a non-void function.
-ERROR SPPG1032 @ (53,7): Invalid next_arg operation.
+ERROR SPPG1032 @ (56,7): Invalid next_arg operation.
 Build Failed...
 --------------------- Partial LLVM IR ----------------------
 ; ModuleID = 'AlususProgram'
@@ -12,6 +12,7 @@ source_filename = "AlususProgram"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
 %LlvmGlobalCtorDtor = type { i32, void ()*, i32* }
+%Main_Mt = type { i32 }
 %__VaList = type { i32, i32, i8*, i8* }
 
 @"#anonymous0" = private constant [6 x i8] c"hello\00"
@@ -51,6 +52,9 @@ define i32 @"Main.main()=>(Int[32])"() {
   call void (i8*, ...) @"Main.f3(ptr[Word[8]],ArgPack[ptr[Word[8]],1,2])"(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"#anonymous8", i32 0, i32 0), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"#anonymous9", i32 0, i32 0), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"#anonymous10", i32 0, i32 0))
   %0 = call i32 (i32, ...) @"Main.f5(Int[32],ArgPack[Int[32],0,0])=>(Int[32])"(i32 5, i32 1, i32 2, i32 -3, i32 7, i32 9)
   %1 = call i32 (i32, ...) @"Main.f5(Int[32],ArgPack[Int[32],0,0])=>(Int[32])"(i32 5, i32 1, i32 2, i32 -3, i32 7, i32 9)
+  %mt = alloca %Main_Mt
+  call void @"Main.Mt.~init(iref[Main.Mt])"(%Main_Mt* %mt)
+  call void (i32, ...) @"Main.f6(Int[32],ArgPack[any,0,0])"(i32 1, %Main_Mt* %mt)
 }
 
 define void @"Main.f0(ptr[Word[8]],ArgPack[Int[32],0,0])"(i8* %a, ...) {
@@ -138,6 +142,29 @@ define i32 @"Main.f5(Int[32],ArgPack[Int[32],0,0])=>(Int[32])"(i32 %count, ...) 
   br label %"#block10"
 }
 
+define void @"Main.Mt.~init(iref[Main.Mt])"(%Main_Mt* %this) {
+"#block16":
+  %this1 = alloca %Main_Mt*
+  store %Main_Mt* %this, %Main_Mt** %this1
+  ret void
+}
+
+define void @"Main.f6(Int[32],ArgPack[any,0,0])"(i32 %count, ...) {
+"#block15":
+  %__vaList = alloca %__VaList
+  %0 = bitcast %__VaList* %__vaList to i8*
+  call void @llvm.va_start(i8* %0)
+  %count1 = alloca i32
+  store i32 %count, i32* %count1
+  %mt = alloca %Main_Mt
+  call void @"Main.Mt.~init(iref[Main.Mt])"(%Main_Mt* %mt)
+  %1 = va_arg %__VaList* %__vaList, %Main_Mt*
+  %2 = call %Main_Mt* @"Main.Mt.=(iref[Main.Mt],ref[Main.Mt])=>(iref[Main.Mt])"(%Main_Mt* %mt, %Main_Mt* %1)
+  %3 = bitcast %__VaList* %__vaList to i8*
+  call void @llvm.va_end(i8* %3)
+  ret void
+}
+
 ; Function Attrs: nounwind
 declare void @llvm.va_start(i8*) #0
 
@@ -178,6 +205,22 @@ define void @"Main.f4(ptr[Word[8]],ArgPack[Word[8],0,0])"(i8* %a, ...) {
   %1 = bitcast %__VaList* %__vaList to i8*
   call void @llvm.va_end(i8* %1)
   ret void
+}
+
+define %Main_Mt* @"Main.Mt.=(iref[Main.Mt],ref[Main.Mt])=>(iref[Main.Mt])"(%Main_Mt* %this, %Main_Mt* %r) {
+"#block17":
+  %this1 = alloca %Main_Mt*
+  store %Main_Mt* %this, %Main_Mt** %this1
+  %r2 = alloca %Main_Mt*
+  store %Main_Mt* %r, %Main_Mt** %r2
+  %0 = load %Main_Mt*, %Main_Mt** %r2
+  %1 = getelementptr %Main_Mt, %Main_Mt* %0, i32 0, i32 0
+  %2 = load %Main_Mt*, %Main_Mt** %this1
+  %3 = getelementptr %Main_Mt, %Main_Mt* %2, i32 0, i32 0
+  %4 = load i32, i32* %1
+  store i32 %4, i32* %3
+  %5 = load %Main_Mt*, %Main_Mt** %this1
+  ret %Main_Mt* %5
 }
 
 attributes #0 = { nounwind }

--- a/Sources/Tests/Spp/Running/temp_objs_test.alusus
+++ b/Sources/Tests/Spp/Running/temp_objs_test.alusus
@@ -84,7 +84,7 @@ func test {
     Console.print("%d\n", D().a.i);
     Console.print(String("string concat ") + M.B().i + "\n");
     def e: E;
-    Console.print("%d, %d\n", e.i, e.j);
+    Console.print("%d, %d\n", e.i, e.j.i);
     def c: C({ A().i, A().i });
     varArgFunc({ A().i, A().i });
     Console.print("%d\n", globalC.i);

--- a/Sources/Tests/Spp/Running/type_ops_test.alusus.output
+++ b/Sources/Tests/Spp/Running/type_ops_test.alusus.output
@@ -66,5 +66,5 @@ ERROR SPPA1008 @ (304,1): Provided arguments do not match signature.
 ERROR SPPA1005 @ (309,3): Multiple matches were found for the given callee.
 ERROR SPPG1002 @ (317,3): Invalid operation.
 ERROR SPPG1002 @ (318,3): Invalid operation.
-ERROR SPPG1002 @ (319,3): Invalid operation.
+ERROR SPPG1015 @ (319,3): Incompatible types for the given operator.
 ERROR SPPG1002 @ (320,3): Invalid operation.

--- a/Sources/Tests/Spp/Running/variadic_functions_test.alusus
+++ b/Sources/Tests/Spp/Running/variadic_functions_test.alusus
@@ -25,6 +25,10 @@ class A {
     handler this~cast[Int] { return this.i };
 };
 
+class B {
+    def i: Int;
+};
+
 Srl.Console.print("%d\n", sum({ 4, 2, 3, 6 }));
 Srl.Console.print("%d\n", sum({ 4, 2; 3, 6 }));
 Srl.Console.print("%d\n", sum({}));
@@ -36,6 +40,22 @@ func sumA(count: Int, args: ...A): Int {
     while count-- > 0 r += args~next_arg[A].i;
     return r;
 }
+func sumAnyA(count: Int, args: ...any): Int {
+    def r: Int = 0;
+    while count-- > 0 r += args~next_arg[A].i;
+    return r;
+}
 Srl.Console.print("%d\n", sumA({ A(12), A(23), A(3) }));
+Srl.Console.print("%d\n", sumAnyA({ A(12), A(23), A(3) }));
+
+func sumB(count: Int, args: ...B): Int {
+    def r: Int = 0;
+    while count-- > 0 r += args~next_arg[B].i;
+    return r;
+}
+Srl.Console.print("%d\n", sumB({ B().{ i = 13 }, B().{ i = 25 }, B().{ i = 7 } }));
+
+def sumBPtr: ptr[func (Int, ...B): Int] = sumB~ptr;
+Srl.Console.print("%d\n", sumBPtr({ B().{ i = 13 }, B().{ i = 25 }, B().{ i = 7 } }));
 
 Srl.Console.print("%d\n", sum({ 4, A(), "wrong" }));

--- a/Sources/Tests/Spp/Running/variadic_functions_test.alusus.output
+++ b/Sources/Tests/Spp/Running/variadic_functions_test.alusus.output
@@ -6,4 +6,7 @@
 0
 14
 38
-ERROR SPPA1008 @ (41,27): Provided arguments do not match signature.
+38
+45
+45
+ERROR SPPA1008 @ (61,27): Provided arguments do not match signature.


### PR DESCRIPTION
* Types with custom initialization are now passed by ref to untyped variadic arguments.
* TargetGenerator automatically convert struct types to pass by reference behind the scenes when they are passed as variadic arguments. This is to fix a limitation in LLVM causing seg faults when struct types are passed by value to variadic arguments.
* Fixed the case where variadic arguments min and max counts are not matching. The target type should have greater or equal min count, and less or equal max count.
* Fixed the error message for assign type mismatch.