### PR TITLE
Removed the plugs from snapcraft.yml.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,15 +43,11 @@ parts:
 apps:
   alusus:
     command: Bin/alusus
-    plugs:
-      - desktop
     slots:
       - dbus-daemon
     common-id: org.alusus
   apm:
     command: Bin/apm
-    plugs:
-      - desktop
     slots:
       - dbus-daemon
     common-id: org.alusus.apm


### PR DESCRIPTION
Plugs are not needed for classic confinement.