### PR TITLE
Fix the build on arm64 architecture.

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -46,6 +46,8 @@ else()
   message(STATUS "The following LLVM path was provided: " ${LLVM_PATH} ".")
 endif()
 
+set(FPIC "" CACHE STRING "The PIC flag to use. This can either be -fpic or -fPIC.")
+
 # Prepare compile and link flags.
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   message(STATUS "Using Clang")

--- a/Sources/Core/CMakeLists.txt
+++ b/Sources/Core/CMakeLists.txt
@@ -20,7 +20,7 @@ set(CMAKE_MODULE_PATH "${AlususCore_SOURCE_DIR}")
 # Add a target for Alusus global storage.
 set(AlususStorage_Source_Files core_global_storage.cpp core_global_storage.h)
 add_library(AlususStorage SHARED ${AlususStorage_Source_Files})
-set_target_properties(AlususStorage PROPERTIES COMPILE_FLAGS "-fpic ${AlususCore_COMPILE_FLAGS}")
+set_target_properties(AlususStorage PROPERTIES COMPILE_FLAGS "${FPIC} ${AlususCore_COMPILE_FLAGS}")
 
 # Add a target for Alusus core library.
 set(AlususCoreLib_Source_Subdirs Basic Data Data/Grammar Data/Ast Notices Processing Processing/Handlers Main)
@@ -33,7 +33,7 @@ foreach (DIR ${AlususCoreLib_Source_Subdirs})
   set(AlususCoreLib_Source_Files ${AlususCoreLib_Source_Files} ${sources} ${headers})
 endforeach(DIR)
 add_library(AlususCoreLib STATIC ${AlususCoreLib_Source_Files})
-set_target_properties(AlususCoreLib PROPERTIES COMPILE_FLAGS "-fpic ${AlususCore_COMPILE_FLAGS}")
+set_target_properties(AlususCoreLib PROPERTIES COMPILE_FLAGS "${FPIC} ${AlususCore_COMPILE_FLAGS}")
 ADD_PRECOMPILED_HEADER(AlususCoreLib "core.h")
 
 # Add a target for Alusus core executable.

--- a/Sources/Srt/Srl/CMakeLists.txt
+++ b/Sources/Srt/Srl/CMakeLists.txt
@@ -24,7 +24,7 @@ file(GLOB headers *.h)
 file(GLOB sources *.cpp)
 set(AlususSrlLib_Source_Files ${AlususSrlLib_Source_Files} ${sources} ${headers})
 add_library(AlususSrlLib STATIC ${AlususSrlLib_Source_Files})
-set_target_properties(AlususSrlLib PROPERTIES COMPILE_FLAGS "-fpic ${AlususSrl_COMPILE_FLAGS}")
+set_target_properties(AlususSrlLib PROPERTIES COMPILE_FLAGS "${FPIC} ${AlususSrl_COMPILE_FLAGS}")
 ADD_PRECOMPILED_HEADER(AlususSrlLib "srl.h")
 
 # Set library and executable output names.

--- a/Sources/Tests/CMakeLists.txt
+++ b/Sources/Tests/CMakeLists.txt
@@ -75,7 +75,7 @@ target_link_libraries(AlususTests AlususSrlLib AlususCoreLib AlususStorage "dl")
 # Build C++ interoperability test lib.
 set(CppInteropTest_Source_Files cpp_interop_test.cpp)
 add_library(CppInteropTest SHARED ${CppInteropTest_Source_Files})
-set_target_properties(CppInteropTest PROPERTIES COMPILE_FLAGS "-fpic ${Alusus_COMPILE_FLAGS}")
+set_target_properties(CppInteropTest PROPERTIES COMPILE_FLAGS "${FPIC} ${Alusus_COMPILE_FLAGS}")
 set_target_properties(CppInteropTest PROPERTIES OUTPUT_NAME cpp_interop_test)
 set_target_properties(CppInteropTest PROPERTIES DEBUG_OUTPUT_NAME cpp_interop_test)
 set_target_properties(CppInteropTest PROPERTIES VERSION ${AlususVersion})

--- a/Tools/BuildSrc/build.py
+++ b/Tools/BuildSrc/build.py
@@ -401,11 +401,17 @@ def build_alusus(llvm_path):
     os.chdir(BUILD_PATH)
 
     try:
+        # Determine fpic flag based on architecture type. For arm64 we'll use -fPIC to avoid the `too many GOT entries`
+        # error. For everything else we'll use -fpic to maintain higher performance.
+        arch = subprocess.check_output(['uname', '-m']).decode('utf-8').strip()
+        fpic = '-fPIC' if arch == 'arm64' or arch == 'aarch64' else '-fpic'
+
         cmake_cmd = ["cmake",
                      os.path.join(ALUSUS_ROOT, "Sources"),
                      f"-DCMAKE_BUILD_TYPE={BUILD_TYPE}".format(),
                      f"-DCMAKE_INSTALL_PREFIX={INSTALL_PATH}".format(),
-                     f"-DLLVM_PATH={llvm_path}".format()]
+                     f"-DLLVM_PATH={llvm_path}".format(),
+                     f"-DFPIC={fpic}".format()]
 
         ret = subprocess.call(cmake_cmd)
         if ret != 0:


### PR DESCRIPTION
Use the -fPIC compiler flag instead of -fpic when building on arm64 architectures because -fpic on arm64 is failing with `too many GOT entries` link error.