### PR TITLE
Fixed few bugs.

### DIFF
--- a/Sources/Spp/Ast/CalleeTracer.cpp
+++ b/Sources/Spp/Ast/CalleeTracer.cpp
@@ -86,15 +86,24 @@ void CalleeTracer::_lookupCallee(TiObject *self, CalleeLookupRequest &request, C
           return Core::Data::Seeker::Verb::MOVE;
         }
 
-        // If we are going out of the current function then we should only be able to access global variables.
-        if (
-          searchingFunctionOwners && tracer->helper->isVariable(obj) &&
-          tracer->helper->getVariableDomain(obj) == Ast::DefinitionDomain::FUNCTION
-        ) {
-          result.notice = newSrdObj<Spp::Notices::AccessingLocalVarInOtherFuncNotice>(
-            Core::Data::Ast::findSourceLocation(request.astNode)
-          );
-          return Core::Data::Seeker::Verb::STOP;
+        if (tracer->helper->isVariable(obj)) {
+          auto domain = tracer->helper->getVariableDomain(obj);
+          
+          // If we are going out of the current function then we should only be able to access global variables.
+          if (domain == Ast::DefinitionDomain::FUNCTION && searchingFunctionOwners) {
+            result.notice = newSrdObj<Spp::Notices::AccessingLocalVarInOtherFuncNotice>(
+              Core::Data::Ast::findSourceLocation(request.astNode)
+            );
+            return Core::Data::Seeker::Verb::STOP;
+          }
+
+          // If we are not requesting directly accessible members and instead looking for object or scope members and
+          // we encounter local variables or values (like the auto created this) then we should skip that. This is to
+          // avoid cases where an auto created local variable (for example: this) is unintentionally picked up while
+          // looking through object members.
+          if (domain == DefinitionDomain::FUNCTION && request.mode != CalleeLookupMode::DIRECTLY_ACCESSIBLE) {
+            return Core::Data::Seeker::Verb::MOVE;
+          }
         }
 
         if (action != Core::Data::Seeker::Action::TARGET_MATCH || obj == 0) return Core::Data::Seeker::Verb::MOVE;
@@ -163,7 +172,13 @@ void CalleeTracer::_lookupCallee(TiObject *self, CalleeLookupRequest &request, C
             if (def == 0 || def->getTarget() == 0) continue;
             if (!helper->isVariable(def->getTarget().get())) continue;
             auto domain = helper->getVariableDomain(def);
+
+            // If we are not requesting directly accessible members and instead looking for object or scope members and
+            // we encounter local variables or values (like the auto created this) then we should skip that. This is to
+            // avoid cases where an auto created local variable (for example: this) is unintentionally picked up while
+            // looking through object members.
             if (domain == DefinitionDomain::FUNCTION && request.mode != CalleeLookupMode::DIRECTLY_ACCESSIBLE) continue;
+
             Bool isMember = domain == DefinitionDomain::OBJECT;
             if ((isMember && request.thisType == 0) || (!isMember && request.thisType != 0)) continue;
             auto objType = helper->traceType(def->getTarget().get());

--- a/Sources/Spp/Ast/CalleeTracer.cpp
+++ b/Sources/Spp/Ast/CalleeTracer.cpp
@@ -179,6 +179,9 @@ void CalleeTracer::_lookupCallee(TiObject *self, CalleeLookupRequest &request, C
             // looking through object members.
             if (domain == DefinitionDomain::FUNCTION && request.mode != CalleeLookupMode::DIRECTLY_ACCESSIBLE) continue;
 
+            // If we are going out of the current function then we should ignore local variables of outer functions.
+            if (domain == DefinitionDomain::FUNCTION && searchingFunctionOwners) continue;
+
             Bool isMember = domain == DefinitionDomain::OBJECT;
             if ((isMember && request.thisType == 0) || (!isMember && request.thisType != 0)) continue;
             auto objType = helper->traceType(def->getTarget().get());

--- a/Sources/Spp/Ast/Helper.cpp
+++ b/Sources/Spp/Ast/Helper.cpp
@@ -265,6 +265,7 @@ Type* Helper::__traceType(TiObject *self, TiObject *ref, Bool skipErrors)
         auto tpl = ti_cast<Spp::Ast::Template>(foundObj);
         if (tpl != 0) {
           Core::Data::Ast::List list;
+          list.setSourceLocation(Core::Data::Ast::findSourceLocation(ref));
           TioSharedPtr result;
           if (tpl->matchInstance(&list, helper, result)) {
             type = result.ti_cast_get<Spp::Ast::Type>();

--- a/Sources/Spp/Ast/UserType.cpp
+++ b/Sources/Spp/Ast/UserType.cpp
@@ -31,7 +31,9 @@ TypeMatchStatus UserType::matchTargetType(
           auto obj = def->getTarget().get();
           if (obj != 0 && helper->isInMemVariable(obj)) {
             auto memberType = helper->traceType(obj);
-            auto memberMatchStatus = memberType->matchTargetType(type, helper, ec, opts | TypeMatchOptions::SKIP_DEREF);
+            auto memberMatchStatus = memberType != 0 ?
+              memberType->matchTargetType(type, helper, ec, opts | TypeMatchOptions::SKIP_DEREF) :
+              TypeMatchStatus::NONE;
             if (
               memberMatchStatus == TypeMatchStatus::EXACT || memberMatchStatus == TypeMatchStatus::AGGREGATION ||
               memberMatchStatus == TypeMatchStatus::REF_AGGREGATION

--- a/Sources/Spp/Ast/callee_lookup_defs.h
+++ b/Sources/Spp/Ast/callee_lookup_defs.h
@@ -16,6 +16,21 @@
 namespace Spp::Ast
 {
 
+/**
+ * @enum CalleeLookupMode
+ * @ingroup spp_test
+ * Specifies what sort of callees are you looking for.
+ * 
+ * @var CalleeLookupMode::DIRECTLY_ACCESSIBLE
+ * Specifies that we are looking for elements that are directly accessible from the current scope. These can be members
+ * of the current scope or members of outer scopes.
+ * 
+ * @var CalleeLookupMode::OBJECT_MEMBER
+ * Specifies that we are looking for a member of a specific object.
+ * 
+ * @var CalleeLookupMode::SCOPE_MEMBER
+ * Specifies that we are looking for global variables in a specific scope.
+ */
 s_enum(CalleeLookupMode, DIRECTLY_ACCESSIBLE, OBJECT_MEMBER, SCOPE_MEMBER);
 
 /// @ingroup spp_ast

--- a/Sources/Spp/CodeGen/TypeGenerator.cpp
+++ b/Sources/Spp/CodeGen/TypeGenerator.cpp
@@ -349,9 +349,13 @@ Bool TypeGenerator::_generateUserTypeMemberVars(
       }
     }
   }
+
+  // Even some members fail, we'll still try to generate a target struct with whatever members we have so that we don't
+  // end up with a struct that has no body, which can cause exceptions later on during other operations.
+  if (!session->getTg()->generateStructTypeBody(tgType, &tgMemberTypes, &tgMembers)) return false;
+
   if (!result) return false;
 
-  if (!session->getTg()->generateStructTypeBody(tgType, &tgMemberTypes, &tgMembers)) return false;
   if (tgMemberTypes.getElementCount() != tgMembers.getCount()) {
     throw EXCEPTION(GenericException, S("Unexpected error while generating struct body."));
   }

--- a/Sources/Spp/Handlers/TypeHandlersParsingHandler.h
+++ b/Sources/Spp/Handlers/TypeHandlersParsingHandler.h
@@ -2,7 +2,7 @@
  * @file Spp/Handlers/TypeHandlersParsingHandler.h
  * Contains the header of class Spp::Handlers::TypeHandlersParsingHandler
  *
- * @copyright Copyright (C) 2021 Sarmad Khalid Abdullah
+ * @copyright Copyright (C) 2022 Sarmad Khalid Abdullah
  *
  * @license This file is released under Alusus Public License, Version 1.0.
  * For details on usage and copying conditions read the full license in the
@@ -46,42 +46,42 @@ class TypeHandlersParsingHandler : public Core::Processing::Handlers::GenericPar
 
   private: SharedPtr<Spp::Ast::Block> prepareBody(TioSharedPtr const &stmt);
 
-  private: void createAssignmentHandler(
+  private: Bool createAssignmentHandler(
     Processing::ParserState *state, Core::Data::Ast::AssignmentOperator *assignmentOp,
     SharedPtr<Spp::Ast::Block> const &body, TioSharedPtr const &retType, Mode mode
   );
 
-  private: void createComparisonHandler(
+  private: Bool createComparisonHandler(
     Processing::ParserState *state, Core::Data::Ast::ComparisonOperator *comparisonOp,
     SharedPtr<Spp::Ast::Block> const &body, TioSharedPtr const &retType, Mode mode
   );
 
-  private: void createInfixOpHandler(
+  private: Bool createInfixOpHandler(
     Processing::ParserState *state, Core::Data::Ast::InfixOperator *infixOp,
     SharedPtr<Spp::Ast::Block> const &body, TioSharedPtr const &retType, Mode mode
   );
 
-  private: void createReadHandler(
+  private: Bool createReadHandler(
     Processing::ParserState *state, Core::Data::Ast::LinkOperator *linkOp,
     SharedPtr<Spp::Ast::Block> const &body, TioSharedPtr const &retType, Mode mode
   );
 
-  private: void createInitOpHandler(
+  private: Bool createInitOpHandler(
     Processing::ParserState *state, Spp::Ast::InitOp *initOp,
     SharedPtr<Spp::Ast::Block> const &body
   );
 
-  private: void createTerminateOpHandler(
+  private: Bool createTerminateOpHandler(
     Processing::ParserState *state, Spp::Ast::TerminateOp *terminateOp,
     SharedPtr<Spp::Ast::Block> const &body, Mode mode
   );
 
-  private: void createCastHandler(
+  private: Bool createCastHandler(
     Processing::ParserState *state, Spp::Ast::CastOp *castOp,
     SharedPtr<Spp::Ast::Block> const &body, Mode mode
   );
 
-  private: void createParensOpHandler(
+  private: Bool createParensOpHandler(
     Processing::ParserState *state, Core::Data::Ast::ParamPass *parensOp,
     SharedPtr<Spp::Ast::Block> const &body, TioSharedPtr const &retType, Mode mode
   );

--- a/Sources/Spp/SeekerExtension.cpp
+++ b/Sources/Spp/SeekerExtension.cpp
@@ -251,7 +251,7 @@ Core::Data::Seeker::Verb SeekerExtension::_foreach_paramPassRouting(
       return cb(Core::Data::Seeker::Action::ERROR, notice.get());
     }
   } else {
-    throw EXCEPTION(InvalidArgumentException, S("paramPass"), S("Invalid bracket type."), paramPass->getType());
+    return Core::Data::Seeker::Verb::MOVE;
   }
 }
 

--- a/Sources/Tests/Spp/Parsing/type_ops_test.alusus
+++ b/Sources/Tests/Spp/Parsing/type_ops_test.alusus
@@ -43,6 +43,7 @@ class T {
   handler notThis == Int return notThis.i == value;
   handler notThis + Int: Int return notThis.i + value;
   handler notThis~cast[Int] return notThis.i;
+  handler notThis() {}
 
   handler this = [v: Int] this.i = value;
   handler this = (this: Int) this.i = 5;
@@ -111,6 +112,8 @@ class T {
   handler [T: type] this.myprop(a: T): T as_ptr {}
   handler [T: type] this.myprop(a: T): T as_ptr;
   handler [T: type] this.myprop(a: T): T set_ptr {}
+
+  handler [T: type] myprop(a: T): T {}
 };
 
 dump_ast T;

--- a/Sources/Tests/Spp/Parsing/type_ops_test.alusus.output
+++ b/Sources/Tests/Spp/Parsing/type_ops_test.alusus.output
@@ -9,22 +9,24 @@ ERROR SPPH1020 @ (42,11): Operation target must be `this`.
 ERROR SPPH1020 @ (43,11): Operation target must be `this`.
 ERROR SPPH1020 @ (44,11): Operation target must be `this`.
 ERROR SPPH1020 @ (45,11): Operation target must be `this`.
-ERROR SPPH1022 @ (47,18): Invalid use of square brackets.
-ERROR SPPH1014 @ (48,19): Invalid handler statement.
-ERROR SPPH1018 @ (93,3): ~init operations cannot be pointer based.
-ERROR SPPH1014 @ (94,3): Invalid handler statement.
-ERROR SPPH1019 @ (95,11): Property getter is missing the return type.
-ERROR SPPH1020 @ (96,11): Operation target must be `this`.
-ERROR SPPH1006 @ (97,29): Invalid function arg name.
-ERROR SPPH1022 @ (99,18): Invalid use of square brackets.
-ERROR SPPH1020 @ (100,11): Operation target must be `this`.
-ERROR SPPH1023 @ (101,11): Invalid type property identifier.
-ERROR SPPH1020 @ (102,11): Operation target must be `this`.
+ERROR SPPH1020 @ (46,11): Operation target must be `this`.
+ERROR SPPH1022 @ (48,18): Invalid use of square brackets.
+ERROR SPPH1014 @ (49,19): Invalid handler statement.
+ERROR SPPH1018 @ (94,3): ~init operations cannot be pointer based.
+ERROR SPPH1014 @ (95,3): Invalid handler statement.
+ERROR SPPH1019 @ (96,11): Property getter is missing the return type.
+ERROR SPPH1020 @ (97,11): Operation target must be `this`.
+ERROR SPPH1006 @ (98,29): Invalid function arg name.
+ERROR SPPH1022 @ (100,18): Invalid use of square brackets.
+ERROR SPPH1020 @ (101,11): Operation target must be `this`.
+ERROR SPPH1023 @ (102,11): Invalid type property identifier.
 ERROR SPPH1020 @ (103,11): Operation target must be `this`.
-ERROR SPPH1014 @ (104,11): Invalid handler statement.
-ERROR SPPH1025 @ (111,3): Template handler statement must not be a pointer.
+ERROR SPPH1020 @ (104,11): Operation target must be `this`.
+ERROR SPPH1014 @ (105,11): Invalid handler statement.
 ERROR SPPH1025 @ (112,3): Template handler statement must not be a pointer.
 ERROR SPPH1025 @ (113,3): Template handler statement must not be a pointer.
+ERROR SPPH1025 @ (114,3): Template handler statement must not be a pointer.
+ERROR SPPH1020 @ (116,21): Operation target must be `this`.
 ------------------ Parsed Data Dump ------------------
 UserType [Main.Type]
  body: Block [Main.BlockStatements.StmtList]

--- a/Sources/Tests/Spp/Running/cmd_pack_test.alusus
+++ b/Sources/Tests/Spp/Running/cmd_pack_test.alusus
@@ -39,6 +39,37 @@ Console.print("B().j = %d\n", B()~use_in(self){ j = 3 }.j);
 
 Console.print("B().j = %d\n", B()~use_in(self) no_injection { self.j = 4 }.j);
 
+// Test the case of unintentionally hitting auto-created `this`.
+// Test the case where an auto created `this` gets incorrectly picked by the compiler instead of `this` from an upper
+// scope.
+
+class Parent {
+    def child: Child;
+    handler this~init() {}
+    handler this~init(val: ref[this_type]) {}
+
+    function new (): Parent {
+        return Parent()~use_in(this){
+            child~use_in(self){
+                parent~no_deref = this;
+            };
+        };
+    }
+}
+
+class Child {
+    def i2: Int = 0;
+    def parent: ref[Parent];
+}
+
+func testSkippingAutoThis {
+    Parent.new();
+    Console.print("Success. Auto created `this` was successfully ignored.\n");
+}
+testSkippingAutoThis();
+
+// Test Errors
+
 Console.print("B().j = %d\n", B()~use_in(self) no_injection { j = 5 }.j);
 
 ptr[Char]().{ i = "wrong" };

--- a/Sources/Tests/Spp/Running/cmd_pack_test.alusus.output
+++ b/Sources/Tests/Spp/Running/cmd_pack_test.alusus.output
@@ -12,5 +12,6 @@ Factorial of 5=120
 Factorial of 5=120
 B().j = 3
 B().j = 4
-ERROR SPPA1007 @ (42,63): Unknown symbol.
-ERROR SPPG1015 @ (44,15): Incompatible types for the given operator.
+Success. Auto created `this` was successfully ignored.
+ERROR SPPA1007 @ (73,63): Unknown symbol.
+ERROR SPPG1015 @ (75,15): Incompatible types for the given operator.

--- a/Sources/Tests/Spp/Running/injection_test.alusus
+++ b/Sources/Tests/Spp/Running/injection_test.alusus
@@ -46,6 +46,26 @@ print(
   getO().getA(), getO().getI(), getO().j, getO().k, getO()()
 );
 
+// Test incorrectly accessing a member of an injection through an auto generated `this`.
+
+class Parent {
+    def result: Int;
+}
+
+class Child {
+    @injection def parent: Parent;
+    def j: Int = 0;
+
+    handler this.test() {
+        result = 5;
+    }
+}
+
+def c: Child;
+c.test();
+
+// Test other injection errors
+
 class Wrong {
   def i: Int;
   @shared @injection def o: Outer;

--- a/Sources/Tests/Spp/Running/injection_test.alusus.output
+++ b/Sources/Tests/Spp/Running/injection_test.alusus.output
@@ -1,7 +1,8 @@
 o.a=6, o.i=7, o.j=0, o.k=8
 o.getA()=1, o.getI()=2, o.getJ()=3, o()=5
 getO().getA()=17, getO().getI()=2, getO().j=3, getO().k=4, getO()()=5
-ERROR SPPG1028 @ (51,22)
-from (54,8): Trying to inject a shared definition.
-ERROR SPPG1029 @ (52,14)
-from (54,8): Invalid type for an injected definition.
+ERROR SPPA1007 @ (60,9): Unknown symbol.
+ERROR SPPG1028 @ (71,22)
+from (74,8): Trying to inject a shared definition.
+ERROR SPPG1029 @ (72,14)
+from (74,8): Invalid type for an injected definition.

--- a/Sources/Tests/Spp/Running/template_function_test.alusus
+++ b/Sources/Tests/Spp/Running/template_function_test.alusus
@@ -35,6 +35,7 @@ printf("d.max[Int]: %d\n", d.max[Int](7, 3));
 printf("d.max[Float]: %f\n", d.max[Float[64]](7, 3));
 printf("d.num[Int]: %d\n", d.num[Int]);
 printf("d.num[Float]: %f\n", d.num[Float[64]]);
+printf("Data().min[Int]: %d\n", Data().min[Int](7, 3));
 
 function myFunc [a: ast] {
     preprocess {

--- a/Sources/Tests/Spp/Running/template_function_test.alusus.output
+++ b/Sources/Tests/Spp/Running/template_function_test.alusus.output
@@ -8,10 +8,11 @@ d.max[Int]: 7
 d.max[Float]: 7.000000
 d.num[Int]: 5
 d.num[Float]: 5.500000
+Data().min[Int]: 3
 myFunc: LogOperator
 myFunc: AdditionOperator
 t.min[Float]: 3
-ERROR SPPG1002 @ (67,1): Invalid operation.
 ERROR SPPG1002 @ (68,1): Invalid operation.
-ERROR SPPG1002 @ (69,5): Invalid operation.
+ERROR SPPG1002 @ (69,1): Invalid operation.
 ERROR SPPG1002 @ (70,5): Invalid operation.
+ERROR SPPG1002 @ (71,5): Invalid operation.

--- a/Sources/Tests/Spp/Running/template_type_test.alusus
+++ b/Sources/Tests/Spp/Running/template_type_test.alusus
@@ -56,3 +56,26 @@ function testAstTemplateArgs {
     def c: MyOtherType[a + b];
 }
 testAstTemplateArgs();
+
+// Errors
+
+class Parent [ResultType: type] {
+    def i: Int;
+    def child: Child;
+}
+
+class Child [ResultType: type] {
+    def result: ResultType;
+}
+
+class OtherParent [ResultType: type] {
+    def child: Child;
+}
+
+func testTemplateArgErrors {
+    def obj1: Parent[Int];
+    def obj2: OtherParent[Int];
+    obj1 = OtherParent[Int]();
+    printf("Error...\n");
+}
+testTemplateArgErrors();

--- a/Sources/Tests/Spp/Running/template_type_test.alusus.output
+++ b/Sources/Tests/Spp/Running/template_type_test.alusus.output
@@ -6,3 +6,18 @@ hello world
 default string
 MyOtherType: LogOperator
 MyOtherType: AdditionOperator
+ERROR SPPA1001 @ (64,16)
+from (76,22)
+from (76,15): Template arguments mismatch.
+ERROR SPPA1001 @ (72,16)
+from (77,27)
+from (77,15): Template arguments mismatch.
+ERROR SPPA1001 @ (72,16)
+from (77,27): Template arguments mismatch.
+ERROR SPPA1001 @ (72,16)
+from (77,27): Template arguments mismatch.
+ERROR SPPA1001 @ (72,16)
+from (77,27): Template arguments mismatch.
+ERROR SPPA1001 @ (72,16)
+from (77,27): Template arguments mismatch.
+ERROR SPPG1015 @ (78,5): Incompatible types for the given operator.


### PR DESCRIPTION
* Fixed a bug in handling parsing errors in handler operation.
* Fixed a bug in SeekerExtension when handling ParamPass that results in an exception during pre-processing.
* Fixed a bug in handling missing template arguments.
* Fixed a bug in handling invalid member variables.
* Fixed a bug where an auto created `this` (for class ctors) is incorrectly picked up during callee lookup in some cases.
* Fixed a bug where a constructor's auto generated `this` is picked for injection handling while compiling member functions.