### PR TITLE
Reimplemented temp var custom casting fix.

### DIFF
--- a/Sources/Spp/Ast/Helper.cpp
+++ b/Sources/Spp/Ast/Helper.cpp
@@ -220,7 +220,7 @@ Type* Helper::__traceType(TiObject *self, TiObject *ref, Bool skipErrors)
     type = helper->_traceType(var->getTypeRef().get(), skipErrors);
     var->setType(type);
   } else if (ref->isDerivedFrom<Spp::Ast::ArgPack>()) {
-    // With arg packs we should aready have the type set during the generation of the function signature.
+    // With arg packs we should already have the type set during the generation of the function signature.
     return getAstType(ref);
   } else if (ref->isDerivedFrom<Core::Data::Ast::Bracket>()) {
     auto bracket = static_cast<Core::Data::Ast::Bracket*>(ref);

--- a/Sources/Spp/CodeGen/DestructionNode.h
+++ b/Sources/Spp/CodeGen/DestructionNode.h
@@ -1,0 +1,30 @@
+/**
+ * @file Spp/CodeGen/DestructionNode.h
+ * Contains the header of class Spp::CodeGen::DestructionNode.
+ *
+ * @copyright Copyright (C) 2023 Sarmad Khalid Abdullah
+ *
+ * @license This file is released under Alusus Public License, Version 1.0.
+ * For details on usage and copying conditions read the full license in the
+ * accompanying license file or at <https://alusus.org/license.html>.
+ */
+//==============================================================================
+
+#ifndef SPP_CODEGEN_DESTRUCTIONNODE_h
+#define SPP_CODEGEN_DESTRUCTIONNODE_h
+
+namespace Spp::CodeGen
+{
+
+class DestructionNode : public TiObject
+{
+  TYPE_INFO(DestructionNode, TiObject, "Spp.CodeGen", "Spp", "alusus.org");
+
+  Core::Data::Node *astNode;
+  Ast::Type *astType;
+  TioSharedPtr tgVar;
+};
+
+} // namespace
+
+#endif

--- a/Sources/Spp/CodeGen/DestructionStack.h
+++ b/Sources/Spp/CodeGen/DestructionStack.h
@@ -2,7 +2,7 @@
  * @file Spp/CodeGen/DestructionStack.h
  * Contains the header of class Spp::CodeGen::DestructionStack.
  *
- * @copyright Copyright (C) 2021 Sarmad Khalid Abdullah
+ * @copyright Copyright (C) 2023 Sarmad Khalid Abdullah
  *
  * @license This file is released under Alusus Public License, Version 1.0.
  * For details on usage and copying conditions read the full license in the
@@ -27,7 +27,7 @@ class DestructionStack : public TiObject
   //============================================================================
   // Member Variables
 
-  private: PlainList<Core::Data::Node> items;
+  private: SharedList<DestructionNode> items;
   private: std::vector<Int> scopeIndexes;
 
 
@@ -51,14 +51,14 @@ class DestructionStack : public TiObject
 
   public: Int getScopeStartIndex(Int scope) const;
 
-  public: void pushItem(Core::Data::Node *item)
+  public: void pushItem(SharedPtr<DestructionNode> const &item)
   {
     this->items.add(item);
   }
 
-  public: Core::Data::Node* getItem(Int index) const
+  public: DestructionNode* getItem(Int index) const
   {
-    return this->items.get(index);
+    return this->items.get(index).get();
   }
 
   public: Word getItemCount() const

--- a/Sources/Spp/CodeGen/Generation.h
+++ b/Sources/Spp/CodeGen/Generation.h
@@ -2,7 +2,7 @@
  * @file Spp/CodeGen/Generation.h
  * Contains the header of class Spp::CodeGen::Generation.
  *
- * @copyright Copyright (C) 2021 Sarmad Khalid Abdullah
+ * @copyright Copyright (C) 2023 Sarmad Khalid Abdullah
  *
  * @license This file is released under Alusus Public License, Version 1.0.
  * For details on usage and copying conditions read the full license in the
@@ -107,7 +107,8 @@ class Generation : public ObjTiInterface
 
   public: METHOD_BINDING_CACHE(generateTempVar,
     Bool, (
-      Core::Data::Node* /* astNode */, Spp::Ast::Type* /* astType */, Session* /* session */, Bool /* initialize */
+      Core::Data::Node* /* astNode */, Spp::Ast::Type* /* astType */, Session* /* session */, Bool /* initialize */,
+      TioSharedPtr& /* tgVar */
     )
   );
 
@@ -134,8 +135,8 @@ class Generation : public ObjTiInterface
 
   public: METHOD_BINDING_CACHE(registerDestructor,
     void, (
-      Core::Data::Node* /* varAstNode */, Ast::Type* /* astType */, ExecutionContext const* /* ec */,
-      DestructionStack* /* destructionStack */
+      Core::Data::Node* /* varAstNode */, Ast::Type* /* astType */, TioSharedPtr /* tgVar */,
+      ExecutionContext const* /* ec */, DestructionStack* /* destructionStack */
     )
   );
 

--- a/Sources/Spp/CodeGen/Generator.h
+++ b/Sources/Spp/CodeGen/Generator.h
@@ -2,7 +2,7 @@
  * @file Spp/CodeGen/Generator.h
  * Contains the header of class Spp::CodeGen::Generator.
  *
- * @copyright Copyright (C) 2021 Sarmad Khalid Abdullah
+ * @copyright Copyright (C) 2023 Sarmad Khalid Abdullah
  *
  * @license This file is released under Alusus Public License, Version 1.0.
  * For details on usage and copying conditions read the full license in the
@@ -176,7 +176,8 @@ class Generator : public TiObject, public DynamicBinding, public DynamicInterfac
   );
 
   private: static Bool _generateTempVar(
-    TiObject *self, Core::Data::Node *astNode, Spp::Ast::Type *astType, Session *session, Bool initialize
+    TiObject *self, Core::Data::Node *astNode, Spp::Ast::Type *astType, Session *session, Bool initialize,
+    TioSharedPtr &tgVar
   );
 
   private: static Bool _generateVarInitialization(
@@ -198,7 +199,7 @@ class Generator : public TiObject, public DynamicBinding, public DynamicInterfac
   );
 
   private: static void _registerDestructor(
-    TiObject *self, Core::Data::Node *varAstNode, Ast::Type *astType, ExecutionContext const *ec,
+    TiObject *self, Core::Data::Node *varAstNode, Ast::Type *astType, TioSharedPtr tgVar, ExecutionContext const *ec,
     DestructionStack *destructionStack
   );
 

--- a/Sources/Spp/CodeGen/code_gen.h
+++ b/Sources/Spp/CodeGen/code_gen.h
@@ -3,7 +3,7 @@
  * Contains the definitions and include statements of all types in the
  * CodeGen namespace.
  *
- * @copyright Copyright (C) 2021 Sarmad Khalid Abdullah
+ * @copyright Copyright (C) 2023 Sarmad Khalid Abdullah
  *
  * @license This file is released under Alusus Public License, Version 1.0.
  * For details on usage and copying conditions read the full license in the
@@ -147,6 +147,7 @@ class TargetGeneration;
 
 // Helpers
 #include "ExtraDataAccessor.h"
+#include "DestructionNode.h"
 #include "DestructionStack.h"
 #include "Session.h"
 

--- a/Sources/Tests/Srt/Srl/smart_refs_test.alusus
+++ b/Sources/Tests/Srt/Srl/smart_refs_test.alusus
@@ -68,10 +68,16 @@ func test6 {
     Console.print("n1 and n2 are both released\n");
 }
 
+func getComplexNum(): SrdRef[ComplexNum] {
+    return SrdRef[ComplexNum]().{ construct(); x = 7; y = 8 };
+}
+
 func test7 {
     def n: SrdRef[Num] = SrdRef[ComplexNum]().{ construct(); x = 5; y = 6 };
     Console.print("test7: auto cast\n");
     Console.print("%d\n", n.x);
+    def n2: SrdRef[Num] = getComplexNum();
+    Console.print("%d\n", n2.x);
 }
 
 func testAll {

--- a/Sources/Tests/Srt/Srl/smart_refs_test.alusus.output
+++ b/Sources/Tests/Srt/Srl/smart_refs_test.alusus.output
@@ -13,7 +13,10 @@ Num 13 is terminated.
 n1 and n2 are both released
 test7: auto cast
 5
+7
 ComplexNum 6 is terminated.
 Num 5 is terminated.
+ComplexNum 8 is terminated.
+Num 7 is terminated.
 [0;31mERROR SPPA1008: Provided arguments do not match signature.[0m
-  smart_refs_test.alusus (90,9)
+  smart_refs_test.alusus (96,9)


### PR DESCRIPTION
Reimplemented the fix for the issue where temp vars cause an exception when they need to be casted using custom caster in some cases. The previous fix was a hack that proved not to cover all cases, so this is a proper implementation.